### PR TITLE
docs: replace CLAUDE.md examples with generic use cases

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-**git-shadow** is a Rust CLI tool that manages local-only changes in Git repositories. It lets users maintain personal edits (e.g., appending notes to `CLAUDE.md`) that stay active in the working tree but are automatically stripped before each commit, keeping Git history clean.
+**git-shadow** is a Rust CLI tool that manages local-only changes in Git repositories. It lets users maintain personal edits (e.g., debug settings, local config overrides, private notes) that stay active in the working tree but are automatically stripped before each commit, keeping Git history clean.
 
 - **Requirements spec**: `docs/requirements.md` (v4, Japanese)
 - **Detailed usage**: `docs/usage.md` (English), `docs/usage.ja.md` (Japanese)

--- a/README.ja.md
+++ b/README.ja.md
@@ -6,14 +6,14 @@ Git リポジトリ内の**ローカル限定の変更**を管理する CLI ツ�
 
 ## なぜ必要？
 
-主な用途は `CLAUDE.md` などの共有ファイルへの個人的な追記の管理です。自分だけのプロンプトやメモ、コーディング規約を追記しても、チームのコミット履歴を汚しません。
+共有ファイルに個人的な変更を加えたいことがあります — デバッグ設定、ローカル環境のオーバーライド、個人的なメモなど。git-shadow を使えば、それらのローカル編集をチームのコミット履歴に残さずに管理できます。
 
 ## コンセプト
 
 | 種別 | 説明 | 例 |
 |------|------|-----|
-| **overlay** | 既存のトラッキング済みファイルにローカル変更を重ねる | ルートの `CLAUDE.md` に個人メモを追記 |
-| **phantom** | リポジトリに存在しないファイルをローカルだけで作成する | `src/components/CLAUDE.md` を新規作成 |
+| **overlay** | 既存のトラッキング済みファイルにローカル変更を重ねる | 共有の `docker-compose.yml` に個人用デバッグ設定を追加 |
+| **phantom** | リポジトリに存在しないファイルをローカルだけで作成する | `scripts/local-setup.sh` をローカル限定で作成 |
 
 ## クイックスタート
 
@@ -26,19 +26,19 @@ cd your-repo
 git-shadow install
 
 # overlay を追加（既存のトラッキング済みファイル）
-git-shadow add CLAUDE.md
-echo "# 個人メモ" >> CLAUDE.md
+git-shadow add docker-compose.yml
+echo "  # 個人用デバッグポート" >> docker-compose.yml
 
 # phantom を追加（新規ローカル限定ファイル）
-echo "# コンポーネント用ドキュメント" > src/components/CLAUDE.md
-git-shadow add --phantom src/components/CLAUDE.md
+echo "#!/bin/bash" > scripts/local-setup.sh
+git-shadow add --phantom scripts/local-setup.sh
 
 # 普通にコミット — shadow 変更は自動的に除外される
 git add -A && git commit -m "チームの変更"
 
-# 確認: 個人メモはワーキングツリーに残っている
-cat CLAUDE.md  # 追記内容あり
-git show HEAD:CLAUDE.md  # クリーンなチーム用の内容のみ
+# 確認: 個人的な変更はワーキングツリーに残っている
+cat docker-compose.yml        # 個人の追記あり
+git show HEAD:docker-compose.yml  # クリーンなチーム用の内容のみ
 ```
 
 ## コマンド一覧

--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ A CLI tool for managing **local-only changes** in Git repositories. Your edits s
 
 ## Why?
 
-The primary use case is managing personal additions to shared files like `CLAUDE.md`. You can append your own prompts, notes, or coding conventions without polluting the team's commit history.
+Sometimes you need personal changes to shared files — debug settings in a config, local environment overrides, or private notes. git-shadow lets you maintain those local edits without them ever appearing in the team's commit history.
 
 ## Concepts
 
 | Type | Description | Example |
 |------|-------------|---------|
-| **overlay** | Layer local changes on top of an existing tracked file | Append personal notes to the root `CLAUDE.md` |
-| **phantom** | Create a file that exists only locally and is never committed | Add `src/components/CLAUDE.md` as a new local-only file |
+| **overlay** | Layer local changes on top of an existing tracked file | Add personal debug settings to a shared `docker-compose.yml` |
+| **phantom** | Create a file that exists only locally and is never committed | Create a local-only `scripts/local-setup.sh` for your environment |
 
 ## Quick Start
 
@@ -26,19 +26,19 @@ cd your-repo
 git-shadow install
 
 # Add an overlay (existing tracked file)
-git-shadow add CLAUDE.md
-echo "# My personal notes" >> CLAUDE.md
+git-shadow add docker-compose.yml
+echo "  # my debug port override" >> docker-compose.yml
 
 # Add a phantom (new local-only file)
-echo "# Component docs" > src/components/CLAUDE.md
-git-shadow add --phantom src/components/CLAUDE.md
+echo "#!/bin/bash" > scripts/local-setup.sh
+git-shadow add --phantom scripts/local-setup.sh
 
 # Commit as usual — shadow changes are automatically excluded
 git add -A && git commit -m "team changes"
 
-# Verify: your personal notes are still in the working tree
-cat CLAUDE.md  # includes your additions
-git show HEAD:CLAUDE.md  # clean, team-only content
+# Verify: your personal changes are still in the working tree
+cat docker-compose.yml        # includes your additions
+git show HEAD:docker-compose.yml  # clean, team-only content
 ```
 
 ## Commands

--- a/docs/usage.ja.md
+++ b/docs/usage.ja.md
@@ -35,10 +35,10 @@ git-shadow install
 
 ```bash
 # トラッキング済みファイルを登録
-git-shadow add CLAUDE.md
+git-shadow add docker-compose.yml
 
 # 自由に編集 — あなたの変更は「shadow 変更」になる
-echo "# 個人用デバッグメモ" >> CLAUDE.md
+echo "  # 個人用デバッグポート" >> docker-compose.yml
 ```
 
 **コミット時の動作:**
@@ -55,8 +55,8 @@ echo "# 個人用デバッグメモ" >> CLAUDE.md
 
 ```bash
 # 新しいローカル限定ファイルを作成して登録
-echo "# コンポーネント専用プロンプト" > src/components/CLAUDE.md
-git-shadow add --phantom src/components/CLAUDE.md
+echo "#!/bin/bash" > scripts/local-setup.sh
+git-shadow add --phantom scripts/local-setup.sh
 ```
 
 デフォルトでは `.git/info/exclude` に追加され、`git status` に表示されなくなります。
@@ -67,7 +67,7 @@ git-shadow add --phantom src/components/CLAUDE.md
 ### 管理の解除
 
 ```bash
-git-shadow remove CLAUDE.md
+git-shadow remove docker-compose.yml
 ```
 
 - **Overlay**: ファイルをベースラインの内容に戻します。shadow 変更は破棄されます。
@@ -95,7 +95,7 @@ git-shadow status
 git-shadow diff
 
 # 特定ファイルの変更を表示
-git-shadow diff CLAUDE.md
+git-shadow diff docker-compose.yml
 ```
 
 - **Overlay**: ベースラインと現在の内容のカラー unified diff を表示
@@ -107,10 +107,10 @@ overlay をかけているファイルがチームによって更新された場
 
 ```bash
 # post-merge hook が警告を表示:
-# "warning: baseline for CLAUDE.md is outdated. Run `git-shadow rebase CLAUDE.md`"
+# "warning: baseline for docker-compose.yml is outdated. Run `git-shadow rebase docker-compose.yml`"
 
 # ベースラインを更新し shadow 変更を再適用
-git-shadow rebase CLAUDE.md
+git-shadow rebase docker-compose.yml
 ```
 
 rebase は 3-way merge を実行します:
@@ -143,7 +143,7 @@ warning: stash has remaining files (a previous commit may have been interrupted)
 git-shadow restore
 
 # 特定ファイルを復元
-git-shadow restore CLAUDE.md
+git-shadow restore docker-compose.yml
 ```
 
 `restore` はあらゆる異常状態に対応します:
@@ -172,8 +172,8 @@ git-shadow doctor
 ├── config.json          # 管理対象ファイルのリスト・メタデータ
 ├── lock                 # PID ベースのロックファイル
 ├── baselines/           # ベースラインのスナップショット (URL エンコードされたファイル名)
-│   └── CLAUDE.md
-│   └── src%2Fcomponents%2FCLAUDE.md
+│   └── docker-compose.yml
+│   └── scripts%2Flocal-setup.sh
 └── stash/               # コミット中の一時退避先
     └── ...
 ```
@@ -181,7 +181,7 @@ git-shadow doctor
 ### パスのエンコーディング
 
 ネストしたパスはフラットに保存するため URL エンコードされます:
-- `src/components/CLAUDE.md` → `src%2Fcomponents%2FCLAUDE.md`
+- `scripts/local-setup.sh` → `scripts%2Flocal-setup.sh`
 - `docs/100%done.md` → `docs%2F100%25done.md`
 
 エンコード順序: `%` → `%25` を先に、次に `/` → `%2F`。

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -35,10 +35,10 @@ Use overlays when you want to add personal content to a file that the team alrea
 
 ```bash
 # Register a tracked file
-git-shadow add CLAUDE.md
+git-shadow add docker-compose.yml
 
 # Edit freely — your changes are "shadow" changes
-echo "# My personal debugging notes" >> CLAUDE.md
+echo "  # my debug port override" >> docker-compose.yml
 ```
 
 **What happens on commit:**
@@ -55,8 +55,8 @@ Use phantoms for files that should exist only on your machine.
 
 ```bash
 # Create and register a new local-only file
-echo "# Component-specific prompts" > src/components/CLAUDE.md
-git-shadow add --phantom src/components/CLAUDE.md
+echo "#!/bin/bash" > scripts/local-setup.sh
+git-shadow add --phantom scripts/local-setup.sh
 ```
 
 By default, phantom files are added to `.git/info/exclude` to hide them from `git status`.
@@ -67,7 +67,7 @@ By default, phantom files are added to `.git/info/exclude` to hide them from `gi
 ### Removing Files from Management
 
 ```bash
-git-shadow remove CLAUDE.md
+git-shadow remove docker-compose.yml
 ```
 
 - **Overlay**: Restores the file to its baseline content. Shadow changes are discarded.
@@ -95,7 +95,7 @@ Shows all managed files with:
 git-shadow diff
 
 # Show changes for a specific file
-git-shadow diff CLAUDE.md
+git-shadow diff docker-compose.yml
 ```
 
 - **Overlay**: Shows a colored unified diff between the baseline and current content
@@ -107,10 +107,10 @@ When the team updates a file you have an overlay on (e.g., after `git pull`):
 
 ```bash
 # post-merge hook will warn you:
-# "warning: baseline for CLAUDE.md is outdated. Run `git-shadow rebase CLAUDE.md`"
+# "warning: baseline for docker-compose.yml is outdated. Run `git-shadow rebase docker-compose.yml`"
 
 # Update your baseline and re-apply shadow changes
-git-shadow rebase CLAUDE.md
+git-shadow rebase docker-compose.yml
 ```
 
 The rebase performs a 3-way merge:
@@ -143,7 +143,7 @@ warning: stash has remaining files (a previous commit may have been interrupted)
 git-shadow restore
 
 # Restore a specific file
-git-shadow restore CLAUDE.md
+git-shadow restore docker-compose.yml
 ```
 
 `restore` handles all abnormal states:
@@ -172,8 +172,8 @@ All data lives inside `.git/shadow/`, which is automatically excluded from commi
 ├── config.json          # Managed file list and metadata
 ├── lock                 # PID-based lockfile
 ├── baselines/           # Baseline snapshots (URL-encoded filenames)
-│   └── CLAUDE.md
-│   └── src%2Fcomponents%2FCLAUDE.md
+│   └── docker-compose.yml
+│   └── scripts%2Flocal-setup.sh
 └── stash/               # Temporary stash during commits
     └── ...
 ```
@@ -181,7 +181,7 @@ All data lives inside `.git/shadow/`, which is automatically excluded from commi
 ### Path Encoding
 
 Nested paths are URL-encoded for flat storage:
-- `src/components/CLAUDE.md` → `src%2Fcomponents%2FCLAUDE.md`
+- `scripts/local-setup.sh` → `scripts%2Flocal-setup.sh`
 - `docs/100%done.md` → `docs%2F100%25done.md`
 
 Encoding order: `%` → `%25` first, then `/` → `%2F`.


### PR DESCRIPTION
## Summary

- Replace all `CLAUDE.md`-specific examples in READMEs and usage guides with generic, broadly relatable examples
- **overlay example**: `docker-compose.yml` (personal debug settings on a shared config)
- **phantom example**: `scripts/local-setup.sh` (local-only development script)
- Rewrite "Why?" section to focus on the core value: keeping personal/private content out of commit history
- `docs/requirements.md` is left unchanged (original specification)

## Motivation

The tool's value proposition is broader than CLAUDE.md management — it's about any personal or private content that shouldn't appear in commit history (debug settings, local config overrides, private notes, etc.). The previous documentation could invite the response "just use CLAUDE.local.md", which misses the point.

## Test plan

- [ ] Verify no remaining `CLAUDE.md` references in README.md, README.ja.md, docs/usage.md, docs/usage.ja.md
- [ ] Verify docs/requirements.md is unchanged
- [ ] Verify examples are consistent across English and Japanese versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)