### PR TITLE
feat: add directory phantom support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,7 @@
 |------|-------------|
 | **overlay** | Layer local changes on top of an existing tracked file |
 | **phantom** | A file that exists only locally and is never committed |
+| **phantom dir** | A directory that exists only locally (exclude-only management, no stash/restore) |
 
 ## Architecture
 
@@ -71,7 +72,7 @@ Nested paths are URL-encoded for flat storage in `baselines/` and `stash/`:
 
 ```bash
 cargo build
-cargo test                      # 146 tests (143 unit + 3 E2E)
+cargo test                      # 164 tests (159 unit + 5 E2E)
 cargo clippy -- -D warnings     # Must pass with zero warnings
 cargo fmt --check               # Must pass
 ```

--- a/docs/feature-request-directory-phantom.md
+++ b/docs/feature-request-directory-phantom.md
@@ -1,0 +1,199 @@
+# Feature Request: ディレクトリの phantom サポート
+
+## 概要
+
+`git-shadow add --phantom` でディレクトリを登録した場合、pre-commit フックで `std::fs::read()` がディレクトリに対して呼ばれ、`Is a directory (os error 21)` で失敗する。
+
+## 再現手順
+
+```bash
+git-shadow add --phantom .claude/
+git-shadow add --phantom codemaps/
+git commit  # → Error: failed to read .claude/ Caused by: Is a directory (os error 21)
+```
+
+## ユースケース
+
+Claude Code の `.claude/` ディレクトリや、コードマップ (`codemaps/`)、レポート (`.reports/`) など、**ローカル専用のディレクトリツリー全体**をgit管理対象外にしたい。
+
+現在の回避策は `.git/info/exclude` に手書きすることだが、git-shadow で一元管理できると：
+- `git-shadow status` で phantom ディレクトリも含めた全管理対象を確認できる
+- `git-shadow remove` で exclude エントリも含めたクリーンアップができる
+- 管理方法が統一される
+
+## 問題の原因
+
+### 1. `add --phantom` がディレクトリを検出しない
+
+`src/commands/add.rs:80-109` の `add_phantom()` は `is_tracked()` チェックのみで、パスがファイルかディレクトリかを判定していない。そのため、登録自体は成功してしまう。
+
+### 2. pre-commit フックがファイル前提で `read()` する
+
+`src/hooks/pre_commit.rs:205-223` の `process_phantom()`:
+
+```rust
+if worktree_path.exists() {
+    let content = std::fs::read(&worktree_path)  // ← ここでディレクトリに対してread
+        .with_context(|| format!("failed to read {}", file_path))?;
+    fs_util::atomic_write(&stash_path, &content)?;
+    tx.stashed_phantoms.push(file_path.to_string());
+}
+```
+
+`std::fs::read()` はディレクトリに対して `EISDIR` を返すため失敗する。
+
+### 3. post-commit のリストアも同様にファイル前提
+
+`src/hooks/post_commit.rs:39-43` で stash から `read` → worktree に `write` しているが、ディレクトリの場合これは意味をなさない。
+
+### 4. status コマンドのサイズ表示
+
+`src/commands/status.rs:112-114` で `std::fs::metadata()` → `metadata.len()` を表示しているが、ディレクトリの場合 `len()` はファイルシステム依存の無意味な値を返す。
+
+## 提案する対応
+
+### 方針: phantom ディレクトリは「exclude のみ管理」
+
+phantom ディレクトリの本質は **`.git/info/exclude` への登録** と **`git rm --cached` による unstage** であり、内容の stash/restore は不要。ファイルの phantom と異なり、ディレクトリの中身をバイト列として stash する必要はない。
+
+### 具体的な変更
+
+#### A. config.rs: エントリにディレクトリフラグを追加
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FileEntry {
+    #[serde(rename = "type")]
+    pub file_type: FileType,
+    #[serde(default)]              // 追加: 後方互換
+    pub is_directory: bool,         // 追加
+    // ... 既存フィールド
+}
+```
+
+`is_directory: false` のデフォルトで既存の config.json との後方互換を維持。
+
+#### B. commands/add.rs: ディレクトリ検出
+
+```rust
+fn add_phantom(/* ... */) -> Result<()> {
+    let full_path = git.root.join(normalized);
+    let is_dir = full_path.is_dir();
+
+    // ディレクトリの場合は末尾スラッシュ付きで exclude に登録
+    let exclude_path = if is_dir && !normalized.ends_with('/') {
+        format!("{}/", normalized)
+    } else {
+        normalized.to_string()
+    };
+
+    // ... exclude 登録処理 ...
+
+    config.add_phantom(normalized.to_string(), exclude_mode, is_dir)?;
+    Ok(())
+}
+```
+
+#### C. hooks/pre_commit.rs: ディレクトリはスキップ
+
+```rust
+fn process_phantom(git: &GitRepo, file_path: &str, entry: &FileEntry, tx: &mut PreCommitTransaction) -> Result<()> {
+    if entry.is_directory {
+        // ディレクトリ: stash不要、unstageのみ
+        git.unstage_phantom(file_path)?;
+        return Ok(());
+    }
+    // 既存のファイル処理 ...
+}
+```
+
+`process_files()` から `FileEntry` を渡すように変更が必要。
+
+#### D. hooks/post_commit.rs: ディレクトリ stash はスキップ
+
+stash にディレクトリエントリが存在しないため、既存ロジックで自然にスキップされる。追加変更は不要。
+
+#### E. commands/status.rs: ディレクトリ表示の改善
+
+```rust
+FileType::Phantom => {
+    let label = if entry.is_directory { "phantom dir" } else { "phantom" };
+    println!("  {} ({})", file_path, label);
+    // ...
+    if worktree_path.exists() {
+        if entry.is_directory {
+            // ファイル数を表示
+            let count = std::fs::read_dir(&worktree_path)?.count();
+            println!("    contents: {} entries", count);
+        } else {
+            let metadata = std::fs::metadata(&worktree_path)?;
+            println!("    file size: {}", format_size(metadata.len()));
+        }
+    }
+}
+```
+
+### 影響範囲
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `src/config.rs` | `FileEntry` に `is_directory` フィールド追加 |
+| `src/commands/add.rs` | `add_phantom()` でディレクトリ検出、exclude パスに `/` 付与 |
+| `src/hooks/pre_commit.rs` | `process_phantom()` でディレクトリ時に stash スキップ |
+| `src/commands/status.rs` | ディレクトリ表示の改善 |
+| テスト | 各ファイルにディレクトリケースのテスト追加 |
+
+`post_commit.rs`, `commands/remove.rs`, `commands/rebase.rs` は変更不要（ディレクトリの stash が存在しないため自然にスキップ）。
+
+## 代替案
+
+### 案B: ディレクトリを登録時に個別ファイルに展開
+
+ディレクトリ配下の全ファイルを個別に phantom 登録する。ただし：
+- ファイル追加時に再登録が必要
+- config.json が肥大化する
+- `.git/info/exclude` にディレクトリパターンを書く方がシンプル
+
+→ **案Aの方が自然で簡潔**
+
+### 案C: ディレクトリの phantom 登録を禁止してエラーにする
+
+最小変更だが、ユースケース（ディレクトリ単位の除外管理）が満たせない。
+
+→ **最低限のフォールバックとして、案Aが実装されるまでの暫定対応に適している**
+
+---
+
+## 対応結果
+
+**ステータス: 実装完了**
+
+案A「phantom ディレクトリは exclude のみ管理」で実装した。提案内容をほぼそのまま採用し、加えて提案で「変更不要」とされていた `remove.rs` と `diff.rs` にも対応を入れた。
+
+### 実装内容
+
+提案どおりの変更 (A-E) に加え、以下を追加で対応:
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `src/config.rs` | `is_directory` フィールド追加、`#[serde(default)]` + `#[serde(skip_serializing_if)]` で後方互換 |
+| `src/path.rs` | `normalize_path()` で末尾 `/` をストリップ（config キーの一貫性確保） |
+| `src/commands/add.rs` | ディレクトリ検出、exclude に末尾 `/` 付与、出力メッセージ分岐 |
+| `src/hooks/pre_commit.rs` | `process_phantom()` に `&FileEntry` を渡し、ディレクトリ時に stash スキップ |
+| `src/hooks/post_commit.rs` | 変更なし（提案どおり、stash が存在しないため自然にスキップ） |
+| `src/commands/status.rs` | `(phantom dir)` ラベル、エントリ数表示、`is_dir()` チェック |
+| `src/commands/diff.rs` | **追加対応**: ディレクトリ phantom でエントリ数を表示（`read_to_string()` の EISDIR 回避） |
+| `src/commands/doctor.rs` | **追加対応**: ディレクトリ phantom は `is_dir()` で存在チェック |
+| `src/commands/remove.rs` | **追加対応**: exclude エントリの末尾 `/` を一致させて正しく削除、確認プロンプトも分岐 |
+| `docs/usage.md` | Phantom Directories セクション追加 |
+| `docs/usage.ja.md` | Phantom ディレクトリ セクション追加 |
+
+### テスト
+
+18 テスト追加（146 → 164）:
+- Unit: config (4), path (3), add (4), pre_commit (1), doctor (2), remove (2)
+- E2E: ディレクトリ phantom フルサイクル (1), overlay + directory phantom 混合 (1)
+
+### 提案との差分
+
+提案では `remove.rs` は「変更不要」としていたが、実際には exclude エントリがファイルでは `path`、ディレクトリでは `path/` で登録されるため、削除時にも末尾 `/` の一致が必要だった。同様に `diff.rs` も `read_to_string()` で EISDIR が発生するため対応した。

--- a/docs/usage.ja.md
+++ b/docs/usage.ja.md
@@ -64,6 +64,20 @@ git-shadow add --phantom src/components/CLAUDE.md
 **オプション:**
 - `--no-exclude` — `.git/info/exclude` への追加をスキップ。`git status` には未追跡ファイルとして表示されますが、pre-commit hook によりコミットからは除外されます。
 
+#### Phantom ディレクトリ
+
+ディレクトリ全体を phantom として登録することもできます:
+
+```bash
+# ローカル限定ディレクトリを登録
+git-shadow add --phantom .claude/
+git-shadow add --phantom codemaps/
+```
+
+ディレクトリ phantom は `.git/info/exclude` による管理のみ行われ、stash/restore は不要です。ディレクトリとその中身はワーキングツリーに常に残り、誤って `git add` されたファイルは pre-commit hook で自動的にアンステージされます。
+
+`git-shadow status` ではディレクトリ phantom は `(phantom dir)` ラベルとエントリ数で表示されます。
+
 ### 管理の解除
 
 ```bash

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -64,6 +64,20 @@ By default, phantom files are added to `.git/info/exclude` to hide them from `gi
 **Options:**
 - `--no-exclude` — Skip the `.git/info/exclude` entry. The file will appear in `git status` as untracked but will still be excluded from commits by the pre-commit hook.
 
+#### Phantom Directories
+
+You can also register entire directories as phantoms:
+
+```bash
+# Register a local-only directory
+git-shadow add --phantom .claude/
+git-shadow add --phantom codemaps/
+```
+
+Directory phantoms are managed via `.git/info/exclude` only — no stash/restore is needed. The directory and its contents remain in the working tree at all times, and any accidentally staged files are automatically unstaged by the pre-commit hook.
+
+`git-shadow status` shows directory phantoms with a `(phantom dir)` label and an entry count instead of file size.
+
 ### Removing Files from Management
 
 ```bash

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -99,7 +99,12 @@ pub fn run() -> Result<()> {
                 println!();
             }
             FileType::Phantom => {
-                println!("  {} (phantom)", file_path);
+                let label = if entry.is_directory {
+                    "phantom dir"
+                } else {
+                    "phantom"
+                };
+                println!("  {} ({})", file_path, label);
                 match entry.exclude_mode {
                     crate::config::ExcludeMode::GitInfoExclude => {
                         println!("    exclude: .git/info/exclude");
@@ -109,7 +114,16 @@ pub fn run() -> Result<()> {
                     }
                 }
                 let worktree_path = git.root.join(file_path);
-                if worktree_path.exists() {
+                if entry.is_directory {
+                    if worktree_path.is_dir() {
+                        let count = std::fs::read_dir(&worktree_path)
+                            .map(|entries| entries.count())
+                            .unwrap_or(0);
+                        println!("    contents: {} entries", count);
+                    } else {
+                        println!("{}", "    warning: directory does not exist".yellow());
+                    }
+                } else if worktree_path.exists() {
                     let metadata = std::fs::metadata(&worktree_path)?;
                     println!("    file size: {}", format_size(metadata.len()));
                 } else {

--- a/src/path.rs
+++ b/src/path.rs
@@ -32,6 +32,9 @@ pub fn normalize_path(input: &str, repo_root: &Path) -> Result<String> {
         result = stripped;
     }
 
+    // Strip trailing / (directory indicator)
+    let result = result.trim_end_matches('/');
+
     Ok(result.to_string())
 }
 
@@ -170,6 +173,27 @@ mod tests {
             normalize_path("/repo/src/CLAUDE.md", &repo).unwrap(),
             "src/CLAUDE.md"
         );
+    }
+
+    #[test]
+    fn test_normalize_strips_trailing_slash() {
+        let repo = PathBuf::from("/repo");
+        assert_eq!(normalize_path(".claude/", &repo).unwrap(), ".claude");
+    }
+
+    #[test]
+    fn test_normalize_strips_trailing_slash_nested() {
+        let repo = PathBuf::from("/repo");
+        assert_eq!(
+            normalize_path("src/components/", &repo).unwrap(),
+            "src/components"
+        );
+    }
+
+    #[test]
+    fn test_normalize_dir_with_leading_dot_slash() {
+        let repo = PathBuf::from("/repo");
+        assert_eq!(normalize_path("./.claude/", &repo).unwrap(), ".claude");
     }
 
     #[test]

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -21,6 +21,10 @@ impl TestRepo {
         Self { dir, root }
     }
 
+    pub fn create_dir(&self, path: &str) {
+        std::fs::create_dir_all(self.root.join(path)).unwrap();
+    }
+
     pub fn create_file(&self, path: &str, content: &str) {
         let file_path = self.root.join(path);
         if let Some(parent) = file_path.parent() {


### PR DESCRIPTION
## Summary

- `git-shadow add --phantom <directory>` でディレクトリを phantom 登録できるようになった
- pre-commit フックの `Is a directory (os error 21)` クラッシュを修正
- ディレクトリ phantom は「exclude のみ管理」方式（stash/restore 不要）

## Changes

| File | Change |
|------|--------|
| `src/config.rs` | `FileEntry` に `is_directory` フィールド追加（`#[serde(default)]` で後方互換） |
| `src/path.rs` | `normalize_path()` で末尾 `/` をストリップ |
| `src/commands/add.rs` | ディレクトリ検出、exclude エントリに末尾 `/` 付与 |
| `src/hooks/pre_commit.rs` | ディレクトリ phantom の stash スキップ（コアバグ修正） |
| `src/commands/status.rs` | `(phantom dir)` ラベル、エントリ数表示 |
| `src/commands/diff.rs` | ディレクトリ phantom の `read_to_string()` 回避 |
| `src/commands/doctor.rs` | `is_dir()` チェックで存在検証 |
| `src/commands/remove.rs` | 末尾 `/` 付き exclude エントリの正しい削除 |
| `docs/usage.md`, `docs/usage.ja.md` | Phantom Directories セクション追加 |

## Test plan

- [x] `cargo test` — 164 tests passed (159 unit + 5 E2E)
- [x] `cargo clippy -- -D warnings` — zero warnings
- [x] `cargo fmt --check` — clean
- [ ] Manual: `git-shadow add --phantom .claude/` → `git commit` succeeds
- [ ] Manual: `git-shadow status` shows `(phantom dir)` with entry count
- [ ] Manual: `git-shadow remove .claude --force` cleans up exclude entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)