### PR TITLE
chore: add CI workflow and pre-commit hook for linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  fmt:
+    name: Rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: rustup component add rustfmt
+      - run: cargo fmt --check
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: rustup component add clippy
+      - run: cargo clippy -- -D warnings
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: cargo test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,25 @@ cargo clippy -- -D warnings     # Must pass with zero warnings
 cargo fmt --check               # Must pass
 ```
 
+### CI
+
+GitHub Actions runs on every push to `main` and on pull requests:
+- **fmt** -- `cargo fmt --check`
+- **clippy** -- `cargo clippy -- -D warnings`
+- **test** -- `cargo test`
+
+Configuration: `.github/workflows/ci.yml`
+
+### Pre-commit Hook
+
+A development pre-commit hook is provided in `dev-hooks/`. To enable it:
+
+```bash
+git config core.hooksPath dev-hooks
+```
+
+This runs `cargo fmt --check` and `cargo clippy -- -D warnings` before each commit.
+
 ### TDD Pattern
 
 All features were developed test-first. Unit tests use `*_for_test` helper functions to bypass `std::env::current_dir()` dependency in `GitRepo::discover()`. Each test creates an isolated git repo via `tempfile::tempdir()`.

--- a/dev-hooks/pre-commit
+++ b/dev-hooks/pre-commit
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "==> Running cargo fmt --check"
+cargo fmt --check
+
+echo "==> Running cargo clippy"
+cargo clippy -- -D warnings
+
+echo "==> All checks passed"


### PR DESCRIPTION
- Add GitHub Actions CI with fmt, clippy, and test jobs
- Add dev-hooks/pre-commit running cargo fmt --check and cargo clippy
- Document CI and pre-commit setup in CLAUDE.md

https://claude.ai/code/session_01XKvQhZjmj945FNAHtzWFun