### PR TITLE
chore: add release workflow and installation instructions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,85 @@
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: Build (${{ matrix.target }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: x86_64-apple-darwin
+            os: macos-13
+          - target: aarch64-apple-darwin
+            os: macos-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        run: |
+          rustup update stable
+          rustup target add ${{ matrix.target }}
+
+      - name: Install cross-compilation tools (Linux aarch64)
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
+
+      - name: Build
+        run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Package
+        shell: bash
+        run: |
+          cd target/${{ matrix.target }}/release
+          tar czf ../../../git-shadow-${{ matrix.target }}.tar.gz git-shadow
+          cd ../../..
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: git-shadow-${{ matrix.target }}
+          path: git-shadow-${{ matrix.target }}.tar.gz
+
+  release:
+    name: Create Release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Collect assets
+        run: |
+          mkdir release-assets
+          find artifacts -name '*.tar.gz' -exec mv {} release-assets/ \;
+          cd release-assets
+          for f in *.tar.gz; do
+            sha256sum "$f" >> checksums-sha256.txt
+          done
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: release-assets/*

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,10 @@ name = "git-shadow"
 version = "0.1.0"
 edition = "2021"
 description = "Manage local-only changes in Git repositories"
+license = "MIT"
+repository = "https://github.com/tanabe1478/git-shadow"
+homepage = "https://github.com/tanabe1478/git-shadow"
+readme = "README.md"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 tanabe1478
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.ja.md
+++ b/README.ja.md
@@ -15,12 +15,35 @@ Git リポジトリ内の**ローカル限定の変更**を管理する CLI ツ�
 | **overlay** | 既存のトラッキング済みファイルにローカル変更を重ねる | 共有の `docker-compose.yml` に個人用デバッグ設定を追加 |
 | **phantom** | リポジトリに存在しないファイルをローカルだけで作成する | `scripts/local-setup.sh` をローカル限定で作成 |
 
+## インストール
+
+### ビルド済みバイナリのダウンロード
+
+お使いのプラットフォーム向けのバイナリを [GitHub Releases](https://github.com/tanabe1478/git-shadow/releases/latest) からダウンロードできます:
+
+| プラットフォーム | アーキテクチャ | ダウンロード |
+|----------|-------------|----------|
+| Linux | x86_64 | [git-shadow-x86_64-unknown-linux-gnu.tar.gz](https://github.com/tanabe1478/git-shadow/releases/latest/download/git-shadow-x86_64-unknown-linux-gnu.tar.gz) |
+| Linux | aarch64 | [git-shadow-aarch64-unknown-linux-gnu.tar.gz](https://github.com/tanabe1478/git-shadow/releases/latest/download/git-shadow-aarch64-unknown-linux-gnu.tar.gz) |
+| macOS | Apple Silicon | [git-shadow-aarch64-apple-darwin.tar.gz](https://github.com/tanabe1478/git-shadow/releases/latest/download/git-shadow-aarch64-apple-darwin.tar.gz) |
+| macOS | Intel | [git-shadow-x86_64-apple-darwin.tar.gz](https://github.com/tanabe1478/git-shadow/releases/latest/download/git-shadow-x86_64-apple-darwin.tar.gz) |
+
+```bash
+# 例: macOS Apple Silicon
+curl -LO https://github.com/tanabe1478/git-shadow/releases/latest/download/git-shadow-aarch64-apple-darwin.tar.gz
+tar xzf git-shadow-aarch64-apple-darwin.tar.gz
+sudo mv git-shadow /usr/local/bin/
+```
+
+### ソースからビルド
+
+```bash
+cargo install --path .
+```
+
 ## クイックスタート
 
 ```bash
-# ソースからビルド
-cargo install --path .
-
 # リポジトリで初期化
 cd your-repo
 git-shadow install
@@ -78,7 +101,7 @@ git show HEAD:docker-compose.yml  # クリーンなチーム用の内容のみ
 ## 動作要件
 
 - Git 2.20+
-- Rust 1.70+（ソースからビルドする場合）
+- Rust 1.70+（ソースからビルドする場合のみ）
 
 ## ライセンス
 

--- a/README.md
+++ b/README.md
@@ -15,12 +15,35 @@ Sometimes you need personal changes to shared files — debug settings in a conf
 | **overlay** | Layer local changes on top of an existing tracked file | Add personal debug settings to a shared `docker-compose.yml` |
 | **phantom** | Create a file that exists only locally and is never committed | Create a local-only `scripts/local-setup.sh` for your environment |
 
+## Installation
+
+### Download pre-built binary
+
+Download the latest binary for your platform from [GitHub Releases](https://github.com/tanabe1478/git-shadow/releases/latest):
+
+| Platform | Architecture | Download |
+|----------|-------------|----------|
+| Linux | x86_64 | [git-shadow-x86_64-unknown-linux-gnu.tar.gz](https://github.com/tanabe1478/git-shadow/releases/latest/download/git-shadow-x86_64-unknown-linux-gnu.tar.gz) |
+| Linux | aarch64 | [git-shadow-aarch64-unknown-linux-gnu.tar.gz](https://github.com/tanabe1478/git-shadow/releases/latest/download/git-shadow-aarch64-unknown-linux-gnu.tar.gz) |
+| macOS | Apple Silicon | [git-shadow-aarch64-apple-darwin.tar.gz](https://github.com/tanabe1478/git-shadow/releases/latest/download/git-shadow-aarch64-apple-darwin.tar.gz) |
+| macOS | Intel | [git-shadow-x86_64-apple-darwin.tar.gz](https://github.com/tanabe1478/git-shadow/releases/latest/download/git-shadow-x86_64-apple-darwin.tar.gz) |
+
+```bash
+# Example: macOS Apple Silicon
+curl -LO https://github.com/tanabe1478/git-shadow/releases/latest/download/git-shadow-aarch64-apple-darwin.tar.gz
+tar xzf git-shadow-aarch64-apple-darwin.tar.gz
+sudo mv git-shadow /usr/local/bin/
+```
+
+### Build from source
+
+```bash
+cargo install --path .
+```
+
 ## Quick Start
 
 ```bash
-# Build from source
-cargo install --path .
-
 # Initialize in your repo
 cd your-repo
 git-shadow install
@@ -78,7 +101,7 @@ All data is stored in `.git/shadow/` — inside `.git/`, so it's never committed
 ## Requirements
 
 - Git 2.20+
-- Rust 1.70+ (to build from source)
+- Rust 1.70+ (only if building from source)
 
 ## License
 


### PR DESCRIPTION
## Summary
- GitHub Actions リリースワークフロー追加（タグ push 時にマルチプラットフォームバイナリをビルド）
  - Linux x86_64 / aarch64
  - macOS Intel / Apple Silicon
- MIT LICENSE ファイル追加
- Cargo.toml にメタデータ追加（license, repository, homepage）
- README.md / README.ja.md にインストールセクション追加（ビルド済みバイナリのダウンロードリンク）

## Test plan
- [ ] CI が通ること（fmt, clippy, test）
- [ ] マージ後に `v0.1.0` タグを打ち、リリースワークフローが正常に動作すること
- [ ] 各プラットフォームのバイナリがリリースにアップロードされること

🤖 Generated with [Claude Code](https://claude.com/claude-code)