### PR TITLE
fix: use macos-latest for x86_64 macOS builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
           - target: x86_64-apple-darwin
-            os: macos-13
+            os: macos-latest
           - target: aarch64-apple-darwin
             os: macos-latest
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## Summary
- `macos-13` ランナーが GitHub Actions で廃止されたため、macOS Intel (x86_64) ビルドが失敗していた
- `macos-latest`（ARM）からのクロスコンパイルに変更

## Test plan
- [ ] CI passes
- [ ] マージ後に v0.1.0 タグを打ち直してリリース確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)