### PR TITLE
docs: add suspend/resume documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,8 @@ src/
     diff.rs            # Show shadow changes as unified diff
     rebase.rs          # Update baseline with 3-way merge
     restore.rs         # Recover from interrupted commits
+    suspend.rs         # Suspend shadow changes for branch switching
+    resume.rs          # Resume suspended changes (with 3-way merge)
     doctor.rs          # Diagnose hooks, config, stale state
     hook.rs            # Dispatcher for `git-shadow hook <name>`
   hooks/
@@ -72,7 +74,7 @@ Nested paths are URL-encoded for flat storage in `baselines/` and `stash/`:
 
 ```bash
 cargo build
-cargo test                      # 164 tests (159 unit + 5 E2E)
+cargo test                      # 176 tests (171 unit + 5 E2E)
 cargo clippy -- -D warnings     # Must pass with zero warnings
 cargo fmt --check               # Must pass
 ```

--- a/README.ja.md
+++ b/README.ja.md
@@ -76,6 +76,8 @@ git show HEAD:docker-compose.yml  # クリーンなチーム用の内容のみ
 | `git-shadow diff [file]` | shadow 変更の差分を表示 |
 | `git-shadow rebase [file]` | ベースラインを更新し shadow 変更を再適用 (3-way merge) |
 | `git-shadow restore [file]` | 中断されたコミットやクラッシュからの復旧 |
+| `git-shadow suspend` | ブランチ切替のために shadow 変更を一時退避 |
+| `git-shadow resume` | 退避した shadow 変更を復元（必要に応じて 3-way merge） |
 | `git-shadow doctor` | hooks・設定の整合性・残留状態を診断 |
 
 ## 仕組み

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ git show HEAD:docker-compose.yml  # clean, team-only content
 | `git-shadow diff [file]` | Show shadow changes as a unified diff |
 | `git-shadow rebase [file]` | Update baseline after upstream changes (3-way merge) |
 | `git-shadow restore [file]` | Recover from interrupted commits or crashes |
+| `git-shadow suspend` | Suspend shadow changes for branch switching |
+| `git-shadow resume` | Resume suspended shadow changes (with 3-way merge if needed) |
 | `git-shadow doctor` | Diagnose hooks, config integrity, and stale state |
 
 ## How It Works


### PR DESCRIPTION
## Summary

- Add **Branch Switching** section to `docs/usage.md` and `docs/usage.ja.md` with suspend/resume workflow, restrictions, and typical usage examples
- Add `suspend` / `resume` to command tables in `README.md` and `README.ja.md`
- Update `CLAUDE.md`: test count (176), module structure with `suspend.rs` / `resume.rs`
- Update `src/commands/CLAUDE.md`: command map and design notes for suspend/resume

## Test plan

- [x] Documentation only — no code changes
- [x] Cross-links between EN/JA versions verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added suspend command to temporarily save shadow changes when switching branches.
  * Added resume command to restore suspended shadow changes, with 3-way merge support if the baseline changed.

* **Documentation**
  * Updated command references and usage guides with suspend/resume workflows.
  * Added branch switching section documenting the new workflow and limitations.

* **Tests**
  * Test count increased from 164 to 176.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->