### PR TITLE
[codex] Localize user-facing output and harden path handling

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,6 @@
-use clap::{Parser, Subcommand};
+use clap::{CommandFactory, FromArgMatches, Parser, Subcommand};
+
+use crate::ui::UiLocale;
 
 #[derive(Parser)]
 #[command(
@@ -75,4 +77,143 @@ pub enum Commands {
         /// Hook name (pre-commit, post-commit, post-merge)
         hook_name: String,
     },
+}
+
+impl Cli {
+    pub fn parse_localized(locale: UiLocale) -> Self {
+        let command = localize_command(Self::command(), locale);
+        let matches = command.get_matches();
+        Self::from_arg_matches(&matches).unwrap_or_else(|err| err.exit())
+    }
+}
+
+fn localize_command(command: clap::Command, locale: UiLocale) -> clap::Command {
+    let command = command
+        .about(match locale {
+            UiLocale::Ja => "Git リポジトリ内のローカル専用変更を管理します",
+            UiLocale::En => "Manage local-only changes in Git repositories",
+        })
+        .long_about(match locale {
+            UiLocale::Ja => "Git リポジトリ内のローカル専用変更を管理します",
+            UiLocale::En => "Manage local-only changes in Git repositories",
+        });
+
+    localize_subcommands(command, locale)
+}
+
+fn localize_subcommands(command: clap::Command, locale: UiLocale) -> clap::Command {
+    let command = command.mut_subcommand("install", |sub| {
+        sub.about(match locale {
+            UiLocale::Ja => "Git hooks を設定する",
+            UiLocale::En => "Set up Git hooks",
+        })
+    });
+    let command = command.mut_subcommand("add", |sub| {
+        sub.about(match locale {
+            UiLocale::Ja => "ファイルを shadow 管理に登録する",
+            UiLocale::En => "Register a file for shadow management",
+        })
+        .mut_arg("file", |arg| {
+            arg.help(match locale {
+                UiLocale::Ja => "対象ファイルのパス",
+                UiLocale::En => "Target file path",
+            })
+        })
+        .mut_arg("phantom", |arg| {
+            arg.help(match locale {
+                UiLocale::Ja => "phantom (ローカル専用ファイル) として登録する",
+                UiLocale::En => "Register as a phantom (local-only file)",
+            })
+        })
+        .mut_arg("no_exclude", |arg| {
+            arg.help(match locale {
+                UiLocale::Ja => ".git/info/exclude への追加をスキップする (phantom のみ)",
+                UiLocale::En => "Skip adding to .git/info/exclude (phantom only)",
+            })
+        })
+        .mut_arg("force", |arg| {
+            arg.help(match locale {
+                UiLocale::Ja => "ファイルサイズ制限を無視する",
+                UiLocale::En => "Ignore file size limit",
+            })
+        })
+    });
+    let command = command.mut_subcommand("remove", |sub| {
+        sub.about(match locale {
+            UiLocale::Ja => "ファイルを shadow 管理から外す",
+            UiLocale::En => "Unregister a file from shadow management",
+        })
+        .mut_arg("file", |arg| {
+            arg.help(match locale {
+                UiLocale::Ja => "対象ファイルのパス",
+                UiLocale::En => "Target file path",
+            })
+        })
+        .mut_arg("force", |arg| {
+            arg.help(match locale {
+                UiLocale::Ja => "確認プロンプトをスキップする",
+                UiLocale::En => "Skip confirmation prompt",
+            })
+        })
+    });
+    let command = command.mut_subcommand("status", |sub| {
+        sub.about(match locale {
+            UiLocale::Ja => "管理対象ファイルと状態を表示する",
+            UiLocale::En => "Show managed files and their status",
+        })
+    });
+    let command = command.mut_subcommand("diff", |sub| {
+        sub.about(match locale {
+            UiLocale::Ja => "shadow changes を diff 表示する",
+            UiLocale::En => "Show shadow changes as a diff",
+        })
+        .mut_arg("file", |arg| {
+            arg.help(match locale {
+                UiLocale::Ja => "対象ファイルのパス (省略時は全件)",
+                UiLocale::En => "Target file path (omit for all files)",
+            })
+        })
+    });
+    let command = command.mut_subcommand("rebase", |sub| {
+        sub.about(match locale {
+            UiLocale::Ja => "baseline を更新して shadow changes を再適用する",
+            UiLocale::En => "Update baseline and re-apply shadow changes",
+        })
+        .mut_arg("file", |arg| {
+            arg.help(match locale {
+                UiLocale::Ja => "対象ファイルのパス (省略時は全件)",
+                UiLocale::En => "Target file path (omit for all files)",
+            })
+        })
+    });
+    let command = command.mut_subcommand("restore", |sub| {
+        sub.about(match locale {
+            UiLocale::Ja => "異常状態から回復する",
+            UiLocale::En => "Recover from abnormal state",
+        })
+        .mut_arg("file", |arg| {
+            arg.help(match locale {
+                UiLocale::Ja => "対象ファイルのパス (省略時は全件)",
+                UiLocale::En => "Target file path (omit for all files)",
+            })
+        })
+    });
+    let command = command.mut_subcommand("suspend", |sub| {
+        sub.about(match locale {
+            UiLocale::Ja => "ブランチ切り替えのため shadow changes を退避する",
+            UiLocale::En => "Suspend shadow changes for branch switching",
+        })
+    });
+    let command = command.mut_subcommand("resume", |sub| {
+        sub.about(match locale {
+            UiLocale::Ja => "suspend された shadow changes を復元する",
+            UiLocale::En => "Resume suspended shadow changes",
+        })
+    });
+    command.mut_subcommand("doctor", |sub| {
+        sub.about(match locale {
+            UiLocale::Ja => "hooks と設定を診断する",
+            UiLocale::En => "Diagnose hooks and configuration",
+        })
+    })
 }

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use anyhow::{Context, Result};
 use colored::Colorize;
 
@@ -5,18 +7,30 @@ use crate::config::{ExcludeMode, ShadowConfig};
 use crate::error::ShadowError;
 use crate::exclude::ExcludeManager;
 use crate::git::GitRepo;
+use crate::ui;
 use crate::{fs_util, path};
 
 pub fn run(file: &str, phantom: bool, no_exclude: bool, force: bool) -> Result<()> {
-    let git = GitRepo::discover(&std::env::current_dir()?)?;
-    let normalized = path::normalize_path(file, &git.root)?;
+    let cwd = std::env::current_dir()?;
+    let git = GitRepo::discover(&cwd)?;
+    run_with_repo(&git, &cwd, file, phantom, no_exclude, force)
+}
+
+fn run_with_repo(
+    git: &GitRepo,
+    cwd: &Path,
+    file: &str,
+    phantom: bool,
+    no_exclude: bool,
+    force: bool,
+) -> Result<()> {
+    let locale = ui::detect_locale();
+    let normalized = path::normalize_path(file, cwd, &git.root)?;
+    git.ensure_initialized()?;
 
     // Warn if hooks not installed
     if !git.hooks_installed() {
-        eprintln!(
-            "{}",
-            "warning: hooks not installed. Run `git-shadow install`".yellow()
-        );
+        eprintln!("{}", ui::warning_hooks_not_installed(locale).yellow());
     }
 
     let mut config = ShadowConfig::load(&git.shadow_dir)?;
@@ -37,6 +51,7 @@ fn add_overlay(
     normalized: &str,
     force: bool,
 ) -> Result<()> {
+    let locale = ui::detect_locale();
     // Check file is tracked
     if !git.is_tracked(normalized)? {
         return Err(ShadowError::FileNotTracked(normalized.to_string()).into());
@@ -65,14 +80,17 @@ fn add_overlay(
     config.add_overlay(normalized.to_string(), commit)?;
 
     println!(
-        "registered {} as overlay (baseline: {})",
-        normalized,
-        &config
-            .get(normalized)
-            .unwrap()
-            .baseline_commit
-            .as_deref()
-            .unwrap_or("?")[..7]
+        "{}",
+        ui::registered_overlay(
+            locale,
+            normalized,
+            &config
+                .get(normalized)
+                .unwrap()
+                .baseline_commit
+                .as_deref()
+                .unwrap_or("?")[..7],
+        )
     );
     Ok(())
 }
@@ -113,9 +131,15 @@ fn add_phantom(
     config.add_phantom(normalized.to_string(), exclude_mode, is_dir)?;
 
     if is_dir {
-        println!("registered {} as phantom directory", normalized);
+        println!(
+            "{}",
+            ui::registered_phantom_directory(ui::detect_locale(), normalized)
+        );
     } else {
-        println!("registered {} as phantom", normalized);
+        println!(
+            "{}",
+            ui::registered_phantom(ui::detect_locale(), normalized)
+        );
     }
     Ok(())
 }
@@ -339,5 +363,39 @@ mod tests {
         let mut config = ShadowConfig::new();
         let result = add_phantom(&git, &mut config, "CLAUDE.md", false);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_run_requires_install_before_overlay_add() {
+        let (_dir, git) = make_test_repo();
+        std::fs::remove_dir_all(&git.shadow_dir).unwrap();
+
+        let err = run_with_repo(&git, &git.root, "CLAUDE.md", false, false, false).unwrap_err();
+        assert!(err.to_string().contains("Run `git-shadow install`"));
+    }
+
+    #[test]
+    fn test_run_requires_install_before_phantom_add() {
+        let (_dir, git) = make_test_repo();
+        std::fs::remove_dir_all(&git.shadow_dir).unwrap();
+        std::fs::write(git.root.join("local.md"), "# Local\n").unwrap();
+
+        let err = run_with_repo(&git, &git.root, "local.md", true, false, false).unwrap_err();
+        assert!(err.to_string().contains("Run `git-shadow install`"));
+    }
+
+    #[test]
+    fn test_run_rejects_path_outside_repo() {
+        let (_dir, git) = make_test_repo();
+        let outside_dir = git.root.parent().unwrap().join("outside");
+        std::fs::create_dir_all(&outside_dir).unwrap();
+        std::fs::write(outside_dir.join("local.md"), "# Outside\n").unwrap();
+
+        let cwd = git.root.join("src");
+        std::fs::create_dir_all(&cwd).unwrap();
+
+        let err =
+            run_with_repo(&git, &cwd, "../../outside/local.md", true, false, false).unwrap_err();
+        assert!(err.to_string().contains("outside repository"));
     }
 }

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -36,9 +36,9 @@ fn run_with_repo(
     let mut config = ShadowConfig::load(&git.shadow_dir)?;
 
     if phantom {
-        add_phantom(&git, &mut config, &normalized, no_exclude)?;
+        add_phantom(git, &mut config, &normalized, no_exclude)?;
     } else {
-        add_overlay(&git, &mut config, &normalized, force)?;
+        add_overlay(git, &mut config, &normalized, force)?;
     }
 
     config.save(&git.shadow_dir)?;

--- a/src/commands/diff.rs
+++ b/src/commands/diff.rs
@@ -5,9 +5,12 @@ use crate::diff_util;
 use crate::error::ShadowError;
 use crate::git::GitRepo;
 use crate::path;
+use crate::ui;
 
 pub fn run(file: Option<&str>) -> Result<()> {
-    let git = GitRepo::discover(&std::env::current_dir()?)?;
+    let locale = ui::detect_locale();
+    let cwd = std::env::current_dir()?;
+    let git = GitRepo::discover(&cwd)?;
     let config = ShadowConfig::load(&git.shadow_dir)?;
 
     if config.suspended {
@@ -15,7 +18,7 @@ pub fn run(file: Option<&str>) -> Result<()> {
     }
 
     if config.files.is_empty() {
-        println!("no managed files");
+        println!("{}", ui::no_managed_files(locale));
         return Ok(());
     }
 
@@ -23,7 +26,7 @@ pub fn run(file: Option<&str>) -> Result<()> {
 
     for (file_path, entry) in &config.files {
         if let Some(target) = file {
-            let normalized = path::normalize_path(target, &git.root)?;
+            let normalized = path::normalize_path(target, &cwd, &git.root)?;
             if *file_path != normalized {
                 continue;
             }
@@ -32,24 +35,24 @@ pub fn run(file: Option<&str>) -> Result<()> {
 
         match entry.file_type {
             FileType::Overlay => {
-                show_overlay_diff(&git, file_path)?;
+                show_overlay_diff(&git, file_path, locale)?;
             }
             FileType::Phantom => {
-                show_phantom_diff(&git, file_path, entry)?;
+                show_phantom_diff(&git, file_path, entry, locale)?;
             }
         }
     }
 
     if !found {
         if let Some(target) = file {
-            println!("{} is not managed by git-shadow", target);
+            println!("{}", ui::diff_not_managed(locale, target));
         }
     }
 
     Ok(())
 }
 
-fn show_overlay_diff(git: &GitRepo, file_path: &str) -> Result<()> {
+fn show_overlay_diff(git: &GitRepo, file_path: &str, locale: ui::UiLocale) -> Result<()> {
     let encoded = path::encode_path(file_path);
     let baseline_path = git.shadow_dir.join("baselines").join(&encoded);
     let worktree_path = git.root.join(file_path);
@@ -58,21 +61,26 @@ fn show_overlay_diff(git: &GitRepo, file_path: &str) -> Result<()> {
     let current = std::fs::read_to_string(&worktree_path).unwrap_or_default();
 
     if baseline == current {
-        println!("{}: no shadow changes", file_path);
+        println!("{}", ui::diff_no_shadow_changes(locale, file_path));
         return Ok(());
     }
 
     diff_util::print_colored_diff(
         &baseline,
         &current,
-        &format!("a/{} (baseline)", file_path),
-        &format!("b/{} (shadow)", file_path),
+        &ui::diff_baseline_label(locale, file_path),
+        &ui::diff_shadow_label(locale, file_path),
     );
 
     Ok(())
 }
 
-fn show_phantom_diff(git: &GitRepo, file_path: &str, entry: &FileEntry) -> Result<()> {
+fn show_phantom_diff(
+    git: &GitRepo,
+    file_path: &str,
+    entry: &FileEntry,
+    locale: ui::UiLocale,
+) -> Result<()> {
     let worktree_path = git.root.join(file_path);
 
     if entry.is_directory {
@@ -80,15 +88,15 @@ fn show_phantom_diff(git: &GitRepo, file_path: &str, entry: &FileEntry) -> Resul
             let count = std::fs::read_dir(&worktree_path)
                 .map(|entries| entries.count())
                 .unwrap_or(0);
-            println!("{}: phantom directory ({} entries)", file_path, count);
+            println!("{}", ui::diff_phantom_directory(locale, file_path, count));
         } else {
-            println!("{}: phantom directory does not exist", file_path);
+            println!("{}", ui::diff_phantom_directory_missing(locale, file_path));
         }
         return Ok(());
     }
 
     if !worktree_path.exists() {
-        println!("{}: file does not exist", file_path);
+        println!("{}", ui::diff_file_missing(locale, file_path));
         return Ok(());
     }
 
@@ -240,7 +248,7 @@ mod tests {
         config.save(&git.shadow_dir).unwrap();
 
         // Verify we can match specific file
-        let normalized = path::normalize_path("CLAUDE.md", &git.root).unwrap();
+        let normalized = path::normalize_path("CLAUDE.md", &git.root, &git.root).unwrap();
         assert_eq!(normalized, "CLAUDE.md");
         assert!(config.get(&normalized).is_some());
     }

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -5,11 +5,13 @@ use crate::config::{FileType, ShadowConfig};
 use crate::git::GitRepo;
 use crate::lock::{self, LockStatus};
 use crate::path;
+use crate::ui;
 
 const HOOK_NAMES: &[&str] = &["pre-commit", "post-commit", "post-merge"];
 const COMPETING_HOOKS: &[&str] = &[".husky", ".pre-commit-config.yaml", "lefthook.yml"];
 
 pub fn run() -> Result<()> {
+    let locale = ui::detect_locale();
     let git = GitRepo::discover(&std::env::current_dir()?)?;
     let config = ShadowConfig::load(&git.shadow_dir)?;
 
@@ -17,38 +19,38 @@ pub fn run() -> Result<()> {
     let mut warnings = Vec::new();
 
     // 1. Check hook files
-    check_hooks(&git, &mut issues, &mut warnings);
+    check_hooks(&git, &mut issues, &mut warnings, locale);
 
     // 2. Check competing hook managers
-    check_competing_hooks(&git, &mut warnings);
+    check_competing_hooks(&git, &mut warnings, locale);
 
     // 3. Check config integrity
-    check_config_integrity(&git, &config, &mut issues);
+    check_config_integrity(&git, &config, &mut issues, locale);
 
     // 4. Check stash remnants
-    check_stash(&git, &mut warnings);
+    check_stash(&git, &mut warnings, locale);
 
     // 5. Check lock
-    check_lock(&git, &mut warnings);
+    check_lock(&git, &mut warnings, locale);
 
     // 6. Check suspended state
-    check_suspended(&config, &git, &mut warnings);
+    check_suspended(&config, &git, &mut warnings, locale);
 
     // 7. Check worktree environment
-    check_worktree(&git, &mut warnings);
+    check_worktree(&git, &mut warnings, locale);
 
     // Print results
     if issues.is_empty() && warnings.is_empty() {
-        println!("{}", "all checks passed".green());
+        println!("{}", ui::doctor_all_checks_passed(locale).green());
     } else {
         if !issues.is_empty() {
-            println!("{}", "issues:".red());
+            println!("{}", ui::doctor_issues_heading(locale).red());
             for issue in &issues {
                 println!("  {} {}", "✗".red(), issue);
             }
         }
         if !warnings.is_empty() {
-            println!("{}", "warnings:".yellow());
+            println!("{}", ui::doctor_warnings_heading(locale).yellow());
             for warning in &warnings {
                 println!("  {} {}", "⚠".yellow(), warning);
             }
@@ -58,12 +60,17 @@ pub fn run() -> Result<()> {
     Ok(())
 }
 
-fn check_hooks(git: &GitRepo, issues: &mut Vec<String>, warnings: &mut Vec<String>) {
+fn check_hooks(
+    git: &GitRepo,
+    issues: &mut Vec<String>,
+    warnings: &mut Vec<String>,
+    locale: ui::UiLocale,
+) {
     for hook_name in HOOK_NAMES {
         let hook_path = git.hooks_dir().join(hook_name);
 
         if !hook_path.exists() {
-            issues.push(format!("{} hook does not exist", hook_name));
+            issues.push(ui::doctor_hook_missing(locale, hook_name));
             continue;
         }
 
@@ -73,7 +80,7 @@ fn check_hooks(git: &GitRepo, issues: &mut Vec<String>, warnings: &mut Vec<Strin
             use std::os::unix::fs::PermissionsExt;
             if let Ok(metadata) = std::fs::metadata(&hook_path) {
                 if metadata.permissions().mode() & 0o111 == 0 {
-                    issues.push(format!("{} hook is not executable", hook_name));
+                    issues.push(ui::doctor_hook_not_executable(locale, hook_name));
                 }
             }
         }
@@ -81,56 +88,55 @@ fn check_hooks(git: &GitRepo, issues: &mut Vec<String>, warnings: &mut Vec<Strin
         // Check content calls git-shadow
         if let Ok(content) = std::fs::read_to_string(&hook_path) {
             if !content.contains("git-shadow hook") && !content.contains("git shadow hook") {
-                warnings.push(format!("{} hook does not call git-shadow", hook_name));
+                warnings.push(ui::doctor_hook_not_calling_shadow(locale, hook_name));
             }
         }
     }
 }
 
-fn check_competing_hooks(git: &GitRepo, warnings: &mut Vec<String>) {
+fn check_competing_hooks(git: &GitRepo, warnings: &mut Vec<String>, locale: ui::UiLocale) {
     for marker in COMPETING_HOOKS {
         if git.root.join(marker).exists() {
-            warnings.push(format!("competing hook manager detected: {}", marker));
+            warnings.push(ui::doctor_competing_hook_manager(locale, marker));
         }
     }
 }
 
-fn check_config_integrity(git: &GitRepo, config: &ShadowConfig, issues: &mut Vec<String>) {
+fn check_config_integrity(
+    git: &GitRepo,
+    config: &ShadowConfig,
+    issues: &mut Vec<String>,
+    locale: ui::UiLocale,
+) {
     for (file_path, entry) in &config.files {
         match entry.file_type {
             FileType::Overlay => {
                 let worktree_path = git.root.join(file_path);
                 if !worktree_path.exists() {
-                    issues.push(format!("{} does not exist in working tree", file_path));
+                    issues.push(ui::doctor_overlay_missing_worktree(locale, file_path));
                 }
 
                 let encoded = path::encode_path(file_path);
                 let baseline_path = git.shadow_dir.join("baselines").join(&encoded);
                 if !baseline_path.exists() {
-                    issues.push(format!("baseline file for {} does not exist", file_path));
+                    issues.push(ui::doctor_baseline_missing(locale, file_path));
                 }
             }
             FileType::Phantom => {
                 let worktree_path = git.root.join(file_path);
                 if entry.is_directory {
                     if !worktree_path.is_dir() {
-                        issues.push(format!(
-                            "{} (phantom dir) does not exist in working tree",
-                            file_path
-                        ));
+                        issues.push(ui::doctor_phantom_dir_missing(locale, file_path));
                     }
                 } else if !worktree_path.exists() {
-                    issues.push(format!(
-                        "{} (phantom) does not exist in working tree",
-                        file_path
-                    ));
+                    issues.push(ui::doctor_phantom_missing(locale, file_path));
                 }
             }
         }
     }
 }
 
-fn check_stash(git: &GitRepo, warnings: &mut Vec<String>) {
+fn check_stash(git: &GitRepo, warnings: &mut Vec<String>, locale: ui::UiLocale) {
     let stash_dir = git.shadow_dir.join("stash");
     if stash_dir.exists() {
         let has_files = std::fs::read_dir(&stash_dir)
@@ -143,59 +149,50 @@ fn check_stash(git: &GitRepo, warnings: &mut Vec<String>) {
             .unwrap_or(false);
 
         if has_files {
-            warnings.push("stash has remaining files. Run `git-shadow restore`".to_string());
+            warnings.push(ui::doctor_stash_remaining(locale).to_string());
         }
     }
 }
 
-fn check_suspended(config: &ShadowConfig, git: &GitRepo, warnings: &mut Vec<String>) {
+fn check_suspended(
+    config: &ShadowConfig,
+    git: &GitRepo,
+    warnings: &mut Vec<String>,
+    locale: ui::UiLocale,
+) {
     if config.suspended {
-        warnings.push("shadow changes are suspended. Run `git-shadow resume`".to_string());
+        warnings.push(ui::doctor_suspended(locale).to_string());
 
         // Check if suspended directory exists and has files
         let suspended_dir = git.shadow_dir.join("suspended");
         if !suspended_dir.exists() {
-            warnings.push("suspended directory is missing (state may be corrupted)".to_string());
+            warnings.push(ui::doctor_suspended_dir_missing(locale).to_string());
         }
     }
 }
 
-fn check_worktree(git: &GitRepo, warnings: &mut Vec<String>) {
+fn check_worktree(git: &GitRepo, warnings: &mut Vec<String>, locale: ui::UiLocale) {
     if git.git_dir != git.common_dir {
         // We are in a worktree
         if !git.shadow_dir.exists() {
-            warnings.push(
-                "worktree detected but git-shadow is not initialized here. \
-                 Run `git-shadow install` to set up this worktree"
-                    .to_string(),
-            );
+            warnings.push(ui::doctor_worktree_not_initialized(locale).to_string());
         } else {
             let config_path = git.shadow_dir.join("config.json");
             if !config_path.exists() {
-                warnings.push(
-                    "worktree detected but no shadow config found. \
-                     Run `git-shadow add <file>` to register files in this worktree"
-                        .to_string(),
-                );
+                warnings.push(ui::doctor_worktree_no_config(locale).to_string());
             }
         }
     }
 }
 
-fn check_lock(git: &GitRepo, warnings: &mut Vec<String>) {
+fn check_lock(git: &GitRepo, warnings: &mut Vec<String>, locale: ui::UiLocale) {
     if let Ok(status) = lock::check_lock(&git.shadow_dir) {
         match status {
             LockStatus::Stale(info) => {
-                warnings.push(format!(
-                    "stale lockfile detected (PID {}). Run `git-shadow restore`",
-                    info.pid
-                ));
+                warnings.push(ui::doctor_stale_lock(locale, info.pid));
             }
             LockStatus::HeldByOther(info) => {
-                warnings.push(format!(
-                    "lockfile is held by another process (PID {})",
-                    info.pid
-                ));
+                warnings.push(ui::doctor_lock_held(locale, info.pid));
             }
             _ => {}
         }
@@ -208,6 +205,7 @@ mod tests {
     use crate::fs_util;
     use crate::git::GitRepo;
     use crate::path;
+    use crate::ui::UiLocale;
 
     fn make_test_repo() -> (tempfile::TempDir, GitRepo) {
         let dir = tempfile::tempdir().unwrap();
@@ -251,7 +249,7 @@ mod tests {
         let mut issues = Vec::new();
         let mut warnings = Vec::new();
 
-        super::check_hooks(&git, &mut issues, &mut warnings);
+        super::check_hooks(&git, &mut issues, &mut warnings, UiLocale::En);
 
         // Hooks not installed yet
         assert!(!issues.is_empty());
@@ -281,7 +279,7 @@ mod tests {
 
         let mut issues = Vec::new();
         let mut warnings = Vec::new();
-        super::check_hooks(&git, &mut issues, &mut warnings);
+        super::check_hooks(&git, &mut issues, &mut warnings, UiLocale::En);
 
         assert!(issues.is_empty());
         assert!(warnings.is_empty());
@@ -295,7 +293,7 @@ mod tests {
         std::fs::write(git.root.join(".pre-commit-config.yaml"), "repos: []\n").unwrap();
 
         let mut warnings = Vec::new();
-        super::check_competing_hooks(&git, &mut warnings);
+        super::check_competing_hooks(&git, &mut warnings, UiLocale::En);
 
         assert!(!warnings.is_empty());
         assert!(warnings
@@ -323,7 +321,7 @@ mod tests {
         std::fs::remove_file(git.root.join("CLAUDE.md")).unwrap();
 
         let mut issues = Vec::new();
-        super::check_config_integrity(&git, &config, &mut issues);
+        super::check_config_integrity(&git, &config, &mut issues, UiLocale::En);
 
         assert!(issues
             .iter()
@@ -341,7 +339,7 @@ mod tests {
         config.save(&git.shadow_dir).unwrap();
 
         let mut issues = Vec::new();
-        super::check_config_integrity(&git, &config, &mut issues);
+        super::check_config_integrity(&git, &config, &mut issues, UiLocale::En);
 
         assert!(issues.iter().any(|i| i.contains("baseline file for")));
     }
@@ -353,7 +351,7 @@ mod tests {
         std::fs::write(git.shadow_dir.join("stash").join("old.md"), "remnant").unwrap();
 
         let mut warnings = Vec::new();
-        super::check_stash(&git, &mut warnings);
+        super::check_stash(&git, &mut warnings, UiLocale::En);
 
         assert!(!warnings.is_empty());
         assert!(warnings.iter().any(|w| w.contains("stash")));
@@ -371,7 +369,7 @@ mod tests {
         .unwrap();
 
         let mut warnings = Vec::new();
-        super::check_lock(&git, &mut warnings);
+        super::check_lock(&git, &mut warnings, UiLocale::En);
 
         assert!(!warnings.is_empty());
         assert!(warnings.iter().any(|w| w.contains("stale lockfile")));
@@ -393,7 +391,7 @@ mod tests {
         config.save(&git.shadow_dir).unwrap();
 
         let mut issues = Vec::new();
-        super::check_config_integrity(&git, &config, &mut issues);
+        super::check_config_integrity(&git, &config, &mut issues, UiLocale::En);
 
         assert!(
             issues.iter().any(|i| i.contains("phantom dir")),
@@ -418,7 +416,7 @@ mod tests {
         config.save(&git.shadow_dir).unwrap();
 
         let mut issues = Vec::new();
-        super::check_config_integrity(&git, &config, &mut issues);
+        super::check_config_integrity(&git, &config, &mut issues, UiLocale::En);
 
         assert!(
             issues.is_empty(),
@@ -452,11 +450,11 @@ mod tests {
 
         let mut issues = Vec::new();
         let mut warnings = Vec::new();
-        super::check_hooks(&git, &mut issues, &mut warnings);
-        super::check_competing_hooks(&git, &mut warnings);
-        super::check_config_integrity(&git, &config, &mut issues);
-        super::check_stash(&git, &mut warnings);
-        super::check_lock(&git, &mut warnings);
+        super::check_hooks(&git, &mut issues, &mut warnings, UiLocale::En);
+        super::check_competing_hooks(&git, &mut warnings, UiLocale::En);
+        super::check_config_integrity(&git, &config, &mut issues, UiLocale::En);
+        super::check_stash(&git, &mut warnings, UiLocale::En);
+        super::check_lock(&git, &mut warnings, UiLocale::En);
 
         assert!(issues.is_empty());
         assert!(warnings.is_empty());

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -4,6 +4,7 @@ use anyhow::{Context, Result};
 
 use crate::config::{FileType, ShadowConfig};
 use crate::git::GitRepo;
+use crate::ui;
 use crate::{fs_util, path};
 
 const HOOK_NAMES: &[&str] = &["pre-commit", "post-commit", "post-merge"];
@@ -30,6 +31,7 @@ fi
 }
 
 pub fn run() -> Result<()> {
+    let locale = ui::detect_locale();
     let git = GitRepo::discover(&std::env::current_dir()?)?;
 
     // Create shadow directory structure
@@ -71,7 +73,7 @@ pub fn run() -> Result<()> {
         std::fs::set_permissions(&hook_path, perms)?;
     }
 
-    println!("git-shadow hooks installed successfully");
+    println!("{}", ui::install_success(locale));
     Ok(())
 }
 
@@ -142,7 +144,10 @@ pub fn inherit_from_main_worktree(git: &GitRepo) -> Result<()> {
 
     if inherited_count > 0 {
         local_config.save(&git.shadow_dir)?;
-        println!("inherited {} file(s) from main worktree", inherited_count);
+        println!(
+            "{}",
+            ui::inherited_from_main_worktree(ui::detect_locale(), inherited_count)
+        );
     }
 
     Ok(())

--- a/src/commands/rebase.rs
+++ b/src/commands/rebase.rs
@@ -7,9 +7,12 @@ use crate::fs_util;
 use crate::git::GitRepo;
 use crate::merge;
 use crate::path;
+use crate::ui;
 
 pub fn run(file: Option<&str>) -> Result<()> {
-    let git = GitRepo::discover(&std::env::current_dir()?)?;
+    let locale = ui::detect_locale();
+    let cwd = std::env::current_dir()?;
+    let git = GitRepo::discover(&cwd)?;
     let mut config = ShadowConfig::load(&git.shadow_dir)?;
 
     if config.suspended {
@@ -19,7 +22,7 @@ pub fn run(file: Option<&str>) -> Result<()> {
     let head = git.head_commit()?;
 
     if config.files.is_empty() {
-        println!("no managed files");
+        println!("{}", ui::no_managed_files(locale));
         return Ok(());
     }
 
@@ -34,7 +37,7 @@ pub fn run(file: Option<&str>) -> Result<()> {
         }
 
         if let Some(target) = file {
-            let normalized = path::normalize_path(target, &git.root)?;
+            let normalized = path::normalize_path(target, &cwd, &git.root)?;
             if *file_path != normalized {
                 continue;
             }
@@ -48,7 +51,7 @@ pub fn run(file: Option<&str>) -> Result<()> {
         if let Some(target) = file {
             bail!("{} is not managed as overlay", target);
         } else {
-            println!("no overlay files found");
+            println!("{}", ui::rebase_no_overlay_files(locale));
         }
     }
 
@@ -91,8 +94,8 @@ pub(crate) fn rebase_file(
             entry.baseline_commit = Some(new_head.to_string());
         }
         println!(
-            "{}: baseline content unchanged (commit ref updated)",
-            file_path
+            "{}",
+            ui::rebase_commit_ref_updated(ui::detect_locale(), file_path)
         );
         return Ok(());
     }
@@ -119,14 +122,13 @@ pub(crate) fn rebase_file(
     if merge_result.has_conflicts {
         eprintln!(
             "{}",
-            format!(
-                "warning: conflicts detected in {}. Please resolve manually",
-                file_path
-            )
-            .yellow()
+            ui::rebase_conflicts(ui::detect_locale(), file_path).yellow()
         );
     } else {
-        println!("{}", format!("baseline updated for {}", file_path).green());
+        println!(
+            "{}",
+            ui::rebase_updated(ui::detect_locale(), file_path).green()
+        );
     }
 
     Ok(())

--- a/src/commands/remove.rs
+++ b/src/commands/remove.rs
@@ -1,46 +1,39 @@
-use anyhow::{bail, Result};
+use anyhow::Result;
 use colored::Colorize;
 use is_terminal::IsTerminal;
 
 use crate::config::{ExcludeMode, FileType, ShadowConfig};
+use crate::error::ShadowError;
 use crate::exclude::ExcludeManager;
 use crate::git::GitRepo;
 use crate::path;
+use crate::ui;
 
 pub fn run(file: &str, force: bool) -> Result<()> {
-    let git = GitRepo::discover(&std::env::current_dir()?)?;
+    let locale = ui::detect_locale();
+    let cwd = std::env::current_dir()?;
+    let git = GitRepo::discover(&cwd)?;
     let mut config = ShadowConfig::load(&git.shadow_dir)?;
-    let normalized = path::normalize_path(file, &git.root)?;
+    let normalized = path::normalize_path(file, &cwd, &git.root)?;
 
     let entry = config
         .get(&normalized)
-        .ok_or_else(|| anyhow::anyhow!("{} is not managed by git-shadow", normalized))?
+        .ok_or_else(|| ShadowError::NotManaged(normalized.clone()))?
         .clone();
 
     // Confirmation prompt
     if !force {
         if !std::io::stdin().is_terminal() {
-            bail!("--force is required in non-interactive mode");
+            return Err(ShadowError::NonInteractiveWithoutForce.into());
         }
 
         let prompt = match entry.file_type {
-            FileType::Overlay => {
-                format!(
-                    "Shadow changes for {} will be discarded. Continue? [y/N]",
-                    normalized
-                )
-            }
+            FileType::Overlay => ui::remove_prompt_overlay(locale, &normalized),
             FileType::Phantom => {
                 if entry.is_directory {
-                    format!(
-                        "{} (directory) will be unregistered from shadow management. The directory and its contents will remain. Continue? [y/N]",
-                        normalized
-                    )
+                    ui::remove_prompt_phantom_directory(locale, &normalized)
                 } else {
-                    format!(
-                        "{} will be unregistered from shadow management. The file itself will remain. Continue? [y/N]",
-                        normalized
-                    )
+                    ui::remove_prompt_phantom(locale, &normalized)
                 }
             }
         };
@@ -50,7 +43,7 @@ pub fn run(file: &str, force: bool) -> Result<()> {
         std::io::stdin().read_line(&mut input)?;
         let input = input.trim().to_lowercase();
         if input != "y" && input != "yes" {
-            println!("aborted");
+            println!("{}", ui::aborted(locale));
             return Ok(());
         }
     }
@@ -67,10 +60,7 @@ pub fn run(file: &str, force: bool) -> Result<()> {
     config.remove(&normalized)?;
     config.save(&git.shadow_dir)?;
 
-    println!(
-        "{}",
-        format!("unregistered {} from shadow management", normalized).green()
-    );
+    println!("{}", ui::unregistered(locale, &normalized).green());
 
     Ok(())
 }

--- a/src/commands/restore.rs
+++ b/src/commands/restore.rs
@@ -3,8 +3,10 @@ use anyhow::Result;
 use crate::git::GitRepo;
 use crate::lock;
 use crate::path;
+use crate::ui;
 
 pub fn run(file: Option<&str>) -> Result<()> {
+    let locale = ui::detect_locale();
     let git = GitRepo::discover(&std::env::current_dir()?)?;
     let stash_dir = git.shadow_dir.join("stash");
     let mut restored = Vec::new();
@@ -52,16 +54,16 @@ pub fn run(file: Option<&str>) -> Result<()> {
 
     // Print summary
     if restored.is_empty() && !lock_removed {
-        println!("nothing to restore");
+        println!("{}", ui::restore_nothing(locale));
     } else {
         if !restored.is_empty() {
-            println!("restored files:");
+            println!("{}", ui::restore_heading(locale));
             for f in &restored {
                 println!("  {}", f);
             }
         }
         if lock_removed {
-            println!("lockfile removed");
+            println!("{}", ui::lockfile_removed(locale));
         }
     }
 

--- a/src/commands/resume.rs
+++ b/src/commands/resume.rs
@@ -7,8 +7,10 @@ use crate::fs_util;
 use crate::git::GitRepo;
 use crate::merge;
 use crate::path;
+use crate::ui;
 
 pub fn run() -> Result<()> {
+    let locale = ui::detect_locale();
     let git = GitRepo::discover(&std::env::current_dir()?)?;
     let mut config = ShadowConfig::load(&git.shadow_dir)?;
 
@@ -51,10 +53,7 @@ pub fn run() -> Result<()> {
     config.suspended = false;
     config.save(&git.shadow_dir)?;
 
-    println!(
-        "{}",
-        format!("shadow changes resumed for {} file(s)", count).green()
-    );
+    println!("{}", ui::resume_success(locale, count).green());
 
     Ok(())
 }
@@ -80,7 +79,7 @@ fn resume_overlay(
     if !suspend_path.exists() {
         eprintln!(
             "{}",
-            format!("warning: no suspended content for {}", file_path).yellow()
+            ui::resume_warning_no_suspended_content(ui::detect_locale(), file_path).yellow()
         );
         return Ok(());
     }
@@ -98,8 +97,8 @@ fn resume_overlay(
             std::fs::write(&worktree_path, suspended_content.as_bytes())
                 .with_context(|| format!("failed to restore {}", file_path))?;
             println!(
-                "{}: shadow changes restored (file absent from HEAD)",
-                file_path
+                "{}",
+                ui::resume_restored_file_absent_from_head(ui::detect_locale(), file_path)
             );
             return Ok(());
         }
@@ -109,7 +108,10 @@ fn resume_overlay(
         // Baseline unchanged — restore suspended content directly
         std::fs::write(&worktree_path, suspended_content.as_bytes())
             .with_context(|| format!("failed to restore {}", file_path))?;
-        println!("{}: shadow changes restored", file_path);
+        println!(
+            "{}",
+            ui::resume_restored_shadow_changes(ui::detect_locale(), file_path)
+        );
     } else {
         // Baseline changed — 3-way merge
         let merge_result = merge::three_way_merge(
@@ -133,14 +135,10 @@ fn resume_overlay(
         if merge_result.has_conflicts {
             eprintln!(
                 "{}",
-                format!(
-                    "warning: conflicts detected in {}. Please resolve manually",
-                    file_path
-                )
-                .yellow()
+                ui::resume_conflicts(ui::detect_locale(), file_path).yellow()
             );
         } else {
-            println!("{}: baseline updated and shadow changes merged", file_path);
+            println!("{}", ui::resume_merged(ui::detect_locale(), file_path));
         }
     }
 
@@ -155,7 +153,7 @@ fn resume_phantom(git: &GitRepo, suspended_dir: &std::path::Path, file_path: &st
     if !suspend_path.exists() {
         eprintln!(
             "{}",
-            format!("warning: no suspended content for {}", file_path).yellow()
+            ui::resume_warning_no_suspended_content(ui::detect_locale(), file_path).yellow()
         );
         return Ok(());
     }
@@ -172,7 +170,10 @@ fn resume_phantom(git: &GitRepo, suspended_dir: &std::path::Path, file_path: &st
     std::fs::write(&worktree_path, &content)
         .with_context(|| format!("failed to restore {}", file_path))?;
 
-    println!("{}: phantom file restored", file_path);
+    println!(
+        "{}",
+        ui::resume_phantom_restored(ui::detect_locale(), file_path)
+    );
 
     Ok(())
 }

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -5,8 +5,10 @@ use crate::config::{FileType, ShadowConfig};
 use crate::git::GitRepo;
 use crate::lock::{self, LockStatus};
 use crate::path;
+use crate::ui;
 
 pub fn run() -> Result<()> {
+    let locale = ui::detect_locale();
     let git = GitRepo::discover(&std::env::current_dir()?)?;
     let config = ShadowConfig::load(&git.shadow_dir)?;
 
@@ -18,12 +20,8 @@ pub fn run() -> Result<()> {
             .filter(|e| e.file_type().map(|t| t.is_file()).unwrap_or(false))
             .collect();
         if !stash_files.is_empty() {
-            println!(
-                "{}",
-                "  warning: stash has remaining files (a previous commit may have been interrupted)"
-                    .yellow()
-            );
-            println!("{}", "    -> Run `git-shadow restore`".yellow());
+            println!("{}", ui::status_warning_stash_remaining(locale).yellow());
+            println!("{}", ui::status_action_run_restore(locale).yellow());
             println!();
         }
     }
@@ -32,38 +30,34 @@ pub fn run() -> Result<()> {
     if let LockStatus::Stale(info) = lock::check_lock(&git.shadow_dir)? {
         println!(
             "{}",
-            format!(
-                "  warning: stale lockfile detected (PID {} no longer exists)",
-                info.pid
-            )
-            .yellow()
+            ui::status_warning_stale_lock(locale, info.pid).yellow()
         );
-        println!("{}", "    -> Run `git-shadow restore`".yellow());
+        println!("{}", ui::status_action_run_restore(locale).yellow());
         println!();
     }
 
     if config.files.is_empty() {
-        println!("no managed files");
+        println!("{}", ui::no_managed_files(locale));
         return Ok(());
     }
 
     if config.suspended {
-        println!(
-            "{}",
-            "  status: SUSPENDED (run `git-shadow resume` to restore shadow changes)".yellow()
-        );
+        println!("{}", ui::status_suspended(locale).yellow());
         println!();
     }
 
-    println!("managed files:");
+    println!("{}", ui::status_heading_managed_files(locale));
     println!();
 
     for (file_path, entry) in &config.files {
         match entry.file_type {
             FileType::Overlay => {
-                println!("  {} (overlay)", file_path);
+                println!("  {} ({})", file_path, ui::label_overlay(locale));
                 if let Some(ref commit) = entry.baseline_commit {
-                    println!("    baseline: {}", &commit[..7.min(commit.len())]);
+                    println!(
+                        "{}",
+                        ui::status_baseline(locale, &commit[..7.min(commit.len())])
+                    );
                 }
 
                 // Show diff stats
@@ -74,13 +68,13 @@ pub fn run() -> Result<()> {
                 if !worktree_path.exists() {
                     println!(
                         "{}",
-                        "    warning: file does not exist in working tree".yellow()
+                        ui::status_warning_file_missing_worktree(locale).yellow()
                     );
                 } else if baseline_path.exists() {
                     let baseline = std::fs::read_to_string(&baseline_path).unwrap_or_default();
                     let current = std::fs::read_to_string(&worktree_path).unwrap_or_default();
                     let (added, removed) = diff_stats(&baseline, &current);
-                    println!("    shadow changes: +{} lines / -{} lines", added, removed);
+                    println!("{}", ui::status_shadow_changes(locale, added, removed));
 
                     // Check baseline drift (hash mismatch + content comparison)
                     if let Some(ref commit) = entry.baseline_commit {
@@ -100,8 +94,8 @@ pub fn run() -> Result<()> {
                                 if content_changed {
                                     println!(
                                         "{}",
-                                        format!(
-                                            "    warning: baseline is outdated ({} -> {})",
+                                        ui::status_warning_baseline_outdated(
+                                            locale,
                                             &commit[..7.min(commit.len())],
                                             &head[..7.min(head.len())]
                                         )
@@ -109,8 +103,7 @@ pub fn run() -> Result<()> {
                                     );
                                     println!(
                                         "{}",
-                                        format!("    -> Run `git-shadow rebase {}`", file_path)
-                                            .yellow()
+                                        ui::status_action_run_rebase(locale, file_path).yellow()
                                     );
                                 }
                             }
@@ -121,17 +114,17 @@ pub fn run() -> Result<()> {
             }
             FileType::Phantom => {
                 let label = if entry.is_directory {
-                    "phantom dir"
+                    ui::label_phantom_dir(locale)
                 } else {
-                    "phantom"
+                    ui::label_phantom(locale)
                 };
                 println!("  {} ({})", file_path, label);
                 match entry.exclude_mode {
                     crate::config::ExcludeMode::GitInfoExclude => {
-                        println!("    exclude: .git/info/exclude");
+                        println!("{}", ui::status_exclude_git_info(locale));
                     }
                     crate::config::ExcludeMode::None => {
-                        println!("    exclude: none (hook protection only)");
+                        println!("{}", ui::status_exclude_none(locale));
                     }
                 }
                 let worktree_path = git.root.join(file_path);
@@ -140,15 +133,18 @@ pub fn run() -> Result<()> {
                         let count = std::fs::read_dir(&worktree_path)
                             .map(|entries| entries.count())
                             .unwrap_or(0);
-                        println!("    contents: {} entries", count);
+                        println!("{}", ui::status_contents(locale, count));
                     } else {
-                        println!("{}", "    warning: directory does not exist".yellow());
+                        println!("{}", ui::status_warning_directory_missing(locale).yellow());
                     }
                 } else if worktree_path.exists() {
                     let metadata = std::fs::metadata(&worktree_path)?;
-                    println!("    file size: {}", format_size(metadata.len()));
+                    println!(
+                        "{}",
+                        ui::status_file_size(locale, &format_size(metadata.len()))
+                    );
                 } else {
-                    println!("{}", "    warning: file does not exist".yellow());
+                    println!("{}", ui::status_warning_file_missing(locale).yellow());
                 }
                 println!();
             }

--- a/src/commands/suspend.rs
+++ b/src/commands/suspend.rs
@@ -7,8 +7,10 @@ use crate::fs_util;
 use crate::git::GitRepo;
 use crate::lock::{self, LockStatus};
 use crate::path;
+use crate::ui;
 
 pub fn run() -> Result<()> {
+    let locale = ui::detect_locale();
     let git = GitRepo::discover(&std::env::current_dir()?)?;
     let mut config = ShadowConfig::load(&git.shadow_dir)?;
 
@@ -34,7 +36,7 @@ pub fn run() -> Result<()> {
     }
 
     if config.files.is_empty() {
-        println!("no managed files to suspend");
+        println!("{}", ui::suspend_no_managed_files(locale));
         return Ok(());
     }
 
@@ -62,11 +64,8 @@ pub fn run() -> Result<()> {
     config.suspended = true;
     config.save(&git.shadow_dir)?;
 
-    println!(
-        "{}",
-        format!("shadow changes suspended for {} file(s)", count).green()
-    );
-    println!("working tree is now clean — you can switch branches");
+    println!("{}", ui::suspend_success(locale, count).green());
+    println!("{}", ui::suspend_worktree_clean(locale));
 
     Ok(())
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -239,6 +239,18 @@ impl GitRepo {
             })
     }
 
+    /// Check whether install-created shadow directories exist.
+    pub fn ensure_initialized(&self) -> Result<(), ShadowError> {
+        let baselines_dir = self.shadow_dir.join("baselines");
+        let stash_dir = self.shadow_dir.join("stash");
+
+        if baselines_dir.is_dir() && stash_dir.is_dir() {
+            Ok(())
+        } else {
+            Err(ShadowError::NotInitialized)
+        }
+    }
+
     /// Run a git command and return stdout
     fn run_git(&self, args: &[&str]) -> Result<String, ShadowError> {
         let output = Command::new("git")

--- a/src/hooks/post_commit.rs
+++ b/src/hooks/post_commit.rs
@@ -5,6 +5,7 @@ use crate::config::ShadowConfig;
 use crate::git::GitRepo;
 use crate::lock;
 use crate::path;
+use crate::ui;
 
 pub fn handle(git: &GitRepo) -> Result<()> {
     let _config = ShadowConfig::load(&git.shadow_dir)?;
@@ -45,7 +46,12 @@ pub fn handle(git: &GitRepo) -> Result<()> {
                 Err(e) => {
                     eprintln!(
                         "{}",
-                        format!("warning: failed to restore {}: {}", normalized, e).yellow()
+                        ui::post_commit_restore_failed(
+                            ui::detect_locale(),
+                            &normalized,
+                            &e.to_string()
+                        )
+                        .yellow()
                     );
                     failed.push(normalized.clone());
                 }
@@ -53,7 +59,12 @@ pub fn handle(git: &GitRepo) -> Result<()> {
             Err(e) => {
                 eprintln!(
                     "{}",
-                    format!("warning: failed to read stash for {}: {}", normalized, e).yellow()
+                    ui::post_commit_read_stash_failed(
+                        ui::detect_locale(),
+                        &normalized,
+                        &e.to_string(),
+                    )
+                    .yellow()
                 );
                 failed.push(normalized.clone());
             }
@@ -67,7 +78,7 @@ pub fn handle(git: &GitRepo) -> Result<()> {
         // Partial failure - keep lock
         eprintln!(
             "{}",
-            "warning: some files could not be restored. Run `git-shadow restore`".yellow()
+            ui::post_commit_partial_failure(ui::detect_locale()).yellow()
         );
         for f in &failed {
             eprintln!("  - {}", f);

--- a/src/hooks/post_merge.rs
+++ b/src/hooks/post_merge.rs
@@ -4,6 +4,7 @@ use colored::Colorize;
 use crate::config::{FileType, ShadowConfig};
 use crate::git::GitRepo;
 use crate::path;
+use crate::ui;
 
 pub fn handle(git: &GitRepo) -> Result<()> {
     let config = ShadowConfig::load(&git.shadow_dir)?;
@@ -27,11 +28,7 @@ pub fn handle(git: &GitRepo) -> Result<()> {
                     if baseline_content != head_content {
                         eprintln!(
                             "{}",
-                            format!(
-                                "warning: baseline for {} is outdated.\n  Run `git-shadow rebase {}`",
-                                file_path, file_path
-                            )
-                            .yellow()
+                            ui::baseline_outdated_warning(ui::detect_locale(), file_path).yellow()
                         );
                     }
                 }

--- a/src/hooks/pre_commit.rs
+++ b/src/hooks/pre_commit.rs
@@ -5,6 +5,7 @@ use crate::config::{FileEntry, FileType, ShadowConfig};
 use crate::error::ShadowError;
 use crate::git::GitRepo;
 use crate::lock;
+use crate::ui;
 use crate::{fs_util, path};
 
 /// Tracks stashed files for rollback capability
@@ -51,10 +52,7 @@ impl PreCommitTransaction {
 
 pub fn handle(git: &GitRepo) -> Result<()> {
     // 0. Acquire lock
-    lock::acquire_lock(&git.shadow_dir).map_err(|e| {
-        // Convert StaleLock to anyhow with context
-        anyhow::anyhow!("{}", e)
-    })?;
+    lock::acquire_lock(&git.shadow_dir)?;
 
     let config = ShadowConfig::load(&git.shadow_dir)?;
 
@@ -151,11 +149,7 @@ fn run_soft_checks(git: &GitRepo, config: &ShadowConfig) {
                     if content_changed {
                         eprintln!(
                             "{}",
-                            format!(
-                                "warning: baseline for {} is outdated. Run `git-shadow rebase {}`",
-                                file_path, file_path
-                            )
-                            .yellow()
+                            ui::baseline_outdated_warning(ui::detect_locale(), file_path).yellow()
                         );
                     }
                 }
@@ -216,7 +210,6 @@ fn process_overlay(git: &GitRepo, file_path: &str, tx: &mut PreCommitTransaction
 
     // c. Stage the baseline content
     git.add(file_path)
-        .map_err(|e| anyhow::anyhow!("{}", e))
         .with_context(|| format!("failed to stage {}", file_path))?;
 
     Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,3 +10,4 @@ pub mod hooks;
 pub mod lock;
 pub mod merge;
 pub mod path;
+pub mod ui;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,17 @@
-use anyhow::Result;
-use clap::Parser;
-
 use git_shadow::cli::{Cli, Commands};
 use git_shadow::commands;
+use git_shadow::ui;
 
-fn main() -> Result<()> {
-    let cli = Cli::parse();
+fn main() {
+    if let Err(err) = run() {
+        eprintln!("{}", ui::format_error(&err, ui::detect_locale()));
+        std::process::exit(1);
+    }
+}
+
+fn run() -> anyhow::Result<()> {
+    let locale = ui::detect_locale();
+    let cli = Cli::parse_localized(locale);
 
     match cli.command {
         Commands::Install => commands::install::run()?,

--- a/src/path.rs
+++ b/src/path.rs
@@ -1,41 +1,59 @@
-use std::path::Path;
+use std::path::{Component, Path, PathBuf};
 
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
 
-/// Normalize a user-provided path to repository-relative format:
-/// - Convert to repo-relative path (using / separator)
-/// - Strip leading ./
-pub fn normalize_path(input: &str, repo_root: &Path) -> Result<String> {
-    // Convert backslashes to forward slashes
+/// Normalize a user-provided path to a repository-relative path:
+/// - Resolve relative inputs against the caller's current working directory
+/// - Reject paths that resolve outside the repository root
+/// - Return a forward-slash relative path without "." or ".." segments
+pub fn normalize_path(input: &str, cwd: &Path, repo_root: &Path) -> Result<String> {
     let input = input.replace('\\', "/");
-
-    // If absolute, try to strip repo_root prefix
-    let relative = if input.starts_with('/') {
-        let root_str = repo_root.to_string_lossy().replace('\\', "/");
-        let root_str = root_str.trim_end_matches('/');
-        if let Some(stripped) = input.strip_prefix(root_str) {
-            stripped.trim_start_matches('/').to_string()
-        } else {
-            bail!(
-                "path '{}' is not inside repository '{}'",
-                input,
-                repo_root.display()
-            );
-        }
-    } else {
-        input.to_string()
-    };
-
-    // Strip leading ./ (possibly repeated)
-    let mut result = relative.as_str();
-    while let Some(stripped) = result.strip_prefix("./") {
-        result = stripped;
+    if input.trim().is_empty() {
+        bail!("path cannot be empty");
     }
 
-    // Strip trailing / (directory indicator)
-    let result = result.trim_end_matches('/');
+    let candidate = if Path::new(&input).is_absolute() {
+        PathBuf::from(&input)
+    } else {
+        cwd.join(&input)
+    };
+    let normalized = normalize_lexical(&candidate);
 
-    Ok(result.to_string())
+    if !normalized.starts_with(repo_root) {
+        bail!(
+            "path '{}' resolves outside repository '{}'",
+            input,
+            repo_root.display()
+        );
+    }
+
+    let relative = normalized
+        .strip_prefix(repo_root)
+        .with_context(|| format!("failed to strip repository prefix from '{}'", input))?;
+
+    if relative.as_os_str().is_empty() {
+        bail!("path '{}' resolves to the repository root", input);
+    }
+
+    Ok(relative.to_string_lossy().replace('\\', "/"))
+}
+
+fn normalize_lexical(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+
+    for component in path.components() {
+        match component {
+            Component::Prefix(prefix) => normalized.push(prefix.as_os_str()),
+            Component::RootDir => normalized.push(component.as_os_str()),
+            Component::CurDir => {}
+            Component::ParentDir => {
+                normalized.pop();
+            }
+            Component::Normal(part) => normalized.push(part),
+        }
+    }
+
+    normalized
 }
 
 /// URL-encode a normalized path for use as filename in baselines/ and stash/:
@@ -139,20 +157,26 @@ mod tests {
     #[test]
     fn test_normalize_strips_leading_dot_slash() {
         let repo = PathBuf::from("/repo");
-        assert_eq!(normalize_path("./CLAUDE.md", &repo).unwrap(), "CLAUDE.md");
+        assert_eq!(
+            normalize_path("./CLAUDE.md", &repo, &repo).unwrap(),
+            "CLAUDE.md"
+        );
     }
 
     #[test]
     fn test_normalize_already_relative() {
         let repo = PathBuf::from("/repo");
-        assert_eq!(normalize_path("CLAUDE.md", &repo).unwrap(), "CLAUDE.md");
+        assert_eq!(
+            normalize_path("CLAUDE.md", &repo, &repo).unwrap(),
+            "CLAUDE.md"
+        );
     }
 
     #[test]
     fn test_normalize_nested_path() {
         let repo = PathBuf::from("/repo");
         assert_eq!(
-            normalize_path("src/components/CLAUDE.md", &repo).unwrap(),
+            normalize_path("src/components/CLAUDE.md", &repo, &repo).unwrap(),
             "src/components/CLAUDE.md"
         );
     }
@@ -161,7 +185,7 @@ mod tests {
     fn test_normalize_backslash_to_forward_slash() {
         let repo = PathBuf::from("/repo");
         assert_eq!(
-            normalize_path("src\\components\\CLAUDE.md", &repo).unwrap(),
+            normalize_path("src\\components\\CLAUDE.md", &repo, &repo).unwrap(),
             "src/components/CLAUDE.md"
         );
     }
@@ -170,7 +194,7 @@ mod tests {
     fn test_normalize_absolute_path_within_repo() {
         let repo = PathBuf::from("/repo");
         assert_eq!(
-            normalize_path("/repo/src/CLAUDE.md", &repo).unwrap(),
+            normalize_path("/repo/src/CLAUDE.md", &repo, &repo).unwrap(),
             "src/CLAUDE.md"
         );
     }
@@ -178,14 +202,14 @@ mod tests {
     #[test]
     fn test_normalize_strips_trailing_slash() {
         let repo = PathBuf::from("/repo");
-        assert_eq!(normalize_path(".claude/", &repo).unwrap(), ".claude");
+        assert_eq!(normalize_path(".claude/", &repo, &repo).unwrap(), ".claude");
     }
 
     #[test]
     fn test_normalize_strips_trailing_slash_nested() {
         let repo = PathBuf::from("/repo");
         assert_eq!(
-            normalize_path("src/components/", &repo).unwrap(),
+            normalize_path("src/components/", &repo, &repo).unwrap(),
             "src/components"
         );
     }
@@ -193,12 +217,43 @@ mod tests {
     #[test]
     fn test_normalize_dir_with_leading_dot_slash() {
         let repo = PathBuf::from("/repo");
-        assert_eq!(normalize_path("./.claude/", &repo).unwrap(), ".claude");
+        assert_eq!(
+            normalize_path("./.claude/", &repo, &repo).unwrap(),
+            ".claude"
+        );
     }
 
     #[test]
     fn test_normalize_strips_multiple_leading_dot_slash() {
         let repo = PathBuf::from("/repo");
-        assert_eq!(normalize_path("././CLAUDE.md", &repo).unwrap(), "CLAUDE.md");
+        assert_eq!(
+            normalize_path("././CLAUDE.md", &repo, &repo).unwrap(),
+            "CLAUDE.md"
+        );
+    }
+
+    #[test]
+    fn test_normalize_resolves_parent_dir_inside_repo() {
+        let repo = PathBuf::from("/repo");
+        let cwd = repo.join("src");
+        assert_eq!(
+            normalize_path("../CLAUDE.md", &cwd, &repo).unwrap(),
+            "CLAUDE.md"
+        );
+    }
+
+    #[test]
+    fn test_normalize_rejects_path_outside_repo() {
+        let repo = PathBuf::from("/repo");
+        let cwd = repo.join("src");
+        let err = normalize_path("../../outside.txt", &cwd, &repo).unwrap_err();
+        assert!(err.to_string().contains("resolves outside repository"));
+    }
+
+    #[test]
+    fn test_normalize_rejects_repo_root() {
+        let repo = PathBuf::from("/repo");
+        let err = normalize_path(".", &repo, &repo).unwrap_err();
+        assert!(err.to_string().contains("repository root"));
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,0 +1,852 @@
+use crate::error::ShadowError;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum UiLocale {
+    Ja,
+    En,
+}
+
+pub fn detect_locale() -> UiLocale {
+    detect_locale_from_values(
+        ["LC_ALL", "LC_MESSAGES", "LANG"]
+            .into_iter()
+            .filter_map(|key| std::env::var(key).ok()),
+    )
+}
+
+pub fn format_error(err: &anyhow::Error, locale: UiLocale) -> String {
+    if let Some(shadow_error) = find_shadow_error(err) {
+        return format_shadow_error(shadow_error, locale);
+    }
+
+    match locale {
+        UiLocale::Ja => format!("エラー: {}", err),
+        UiLocale::En => format!("Error: {}", err),
+    }
+}
+
+pub fn warning_hooks_not_installed(locale: UiLocale) -> &'static str {
+    choose(
+        locale,
+        "warning: hooks が未インストールです。`git-shadow install` を実行してください",
+        "warning: hooks not installed. Run `git-shadow install`",
+    )
+}
+
+pub fn registered_overlay(locale: UiLocale, path: &str, baseline: &str) -> String {
+    match locale {
+        UiLocale::Ja => format!("{path} を overlay として登録しました (baseline: {baseline})"),
+        UiLocale::En => format!("registered {path} as overlay (baseline: {baseline})"),
+    }
+}
+
+pub fn registered_phantom(locale: UiLocale, path: &str) -> String {
+    match locale {
+        UiLocale::Ja => format!("{path} を phantom として登録しました"),
+        UiLocale::En => format!("registered {path} as phantom"),
+    }
+}
+
+pub fn registered_phantom_directory(locale: UiLocale, path: &str) -> String {
+    match locale {
+        UiLocale::Ja => format!("{path} を phantom directory として登録しました"),
+        UiLocale::En => format!("registered {path} as phantom directory"),
+    }
+}
+
+pub fn no_managed_files(locale: UiLocale) -> &'static str {
+    choose(locale, "管理対象ファイルはありません", "no managed files")
+}
+
+pub fn not_managed_message(locale: UiLocale, path: &str) -> String {
+    match locale {
+        UiLocale::Ja => format!("{path} は git-shadow の管理対象ではありません"),
+        UiLocale::En => format!("{path} is not managed by git-shadow"),
+    }
+}
+
+pub fn remove_prompt_overlay(locale: UiLocale, path: &str) -> String {
+    match locale {
+        UiLocale::Ja => {
+            format!("{path} の shadow changes は破棄されます。続行しますか? [y/N]")
+        }
+        UiLocale::En => {
+            format!("Shadow changes for {path} will be discarded. Continue? [y/N]")
+        }
+    }
+}
+
+pub fn remove_prompt_phantom(locale: UiLocale, path: &str) -> String {
+    match locale {
+        UiLocale::Ja => format!(
+            "{path} を shadow 管理から外します。ファイル自体は残ります。続行しますか? [y/N]"
+        ),
+        UiLocale::En => format!(
+            "{path} will be unregistered from shadow management. The file itself will remain. Continue? [y/N]"
+        ),
+    }
+}
+
+pub fn remove_prompt_phantom_directory(locale: UiLocale, path: &str) -> String {
+    match locale {
+        UiLocale::Ja => format!(
+            "{path} (directory) を shadow 管理から外します。ディレクトリと中身は残ります。続行しますか? [y/N]"
+        ),
+        UiLocale::En => format!(
+            "{path} (directory) will be unregistered from shadow management. The directory and its contents will remain. Continue? [y/N]"
+        ),
+    }
+}
+
+pub fn aborted(locale: UiLocale) -> &'static str {
+    choose(locale, "中止しました", "aborted")
+}
+
+pub fn unregistered(locale: UiLocale, path: &str) -> String {
+    match locale {
+        UiLocale::Ja => format!("{path} を shadow 管理から解除しました"),
+        UiLocale::En => format!("unregistered {path} from shadow management"),
+    }
+}
+
+pub fn install_success(locale: UiLocale) -> &'static str {
+    choose(
+        locale,
+        "git-shadow hooks をインストールしました",
+        "git-shadow hooks installed successfully",
+    )
+}
+
+pub fn inherited_from_main_worktree(locale: UiLocale, count: usize) -> String {
+    match locale {
+        UiLocale::Ja => format!("main worktree から {count} 件のファイル設定を引き継ぎました"),
+        UiLocale::En => format!("inherited {count} file(s) from main worktree"),
+    }
+}
+
+pub fn diff_not_managed(locale: UiLocale, path: &str) -> String {
+    not_managed_message(locale, path)
+}
+
+pub fn diff_no_shadow_changes(locale: UiLocale, path: &str) -> String {
+    match locale {
+        UiLocale::Ja => format!("{path}: shadow changes はありません"),
+        UiLocale::En => format!("{path}: no shadow changes"),
+    }
+}
+
+pub fn diff_phantom_directory(locale: UiLocale, path: &str, count: usize) -> String {
+    match locale {
+        UiLocale::Ja => format!("{path}: phantom directory ({count} entries)"),
+        UiLocale::En => format!("{path}: phantom directory ({count} entries)"),
+    }
+}
+
+pub fn diff_phantom_directory_missing(locale: UiLocale, path: &str) -> String {
+    match locale {
+        UiLocale::Ja => format!("{path}: phantom directory が存在しません"),
+        UiLocale::En => format!("{path}: phantom directory does not exist"),
+    }
+}
+
+pub fn diff_file_missing(locale: UiLocale, path: &str) -> String {
+    match locale {
+        UiLocale::Ja => format!("{path}: ファイルが存在しません"),
+        UiLocale::En => format!("{path}: file does not exist"),
+    }
+}
+
+pub fn diff_baseline_label(locale: UiLocale, path: &str) -> String {
+    match locale {
+        UiLocale::Ja => format!("a/{path} (baseline)"),
+        UiLocale::En => format!("a/{path} (baseline)"),
+    }
+}
+
+pub fn diff_shadow_label(locale: UiLocale, path: &str) -> String {
+    match locale {
+        UiLocale::Ja => format!("b/{path} (shadow)"),
+        UiLocale::En => format!("b/{path} (shadow)"),
+    }
+}
+
+pub fn restore_nothing(locale: UiLocale) -> &'static str {
+    choose(locale, "復旧するものはありません", "nothing to restore")
+}
+
+pub fn restore_heading(locale: UiLocale) -> &'static str {
+    choose(locale, "復旧したファイル:", "restored files:")
+}
+
+pub fn lockfile_removed(locale: UiLocale) -> &'static str {
+    choose(locale, "lockfile を削除しました", "lockfile removed")
+}
+
+pub fn suspend_no_managed_files(locale: UiLocale) -> &'static str {
+    choose(
+        locale,
+        "suspend する管理対象ファイルはありません",
+        "no managed files to suspend",
+    )
+}
+
+pub fn suspend_success(locale: UiLocale, count: usize) -> String {
+    match locale {
+        UiLocale::Ja => format!("{count} 件の shadow changes を suspend しました"),
+        UiLocale::En => format!("shadow changes suspended for {count} file(s)"),
+    }
+}
+
+pub fn suspend_worktree_clean(locale: UiLocale) -> &'static str {
+    choose(
+        locale,
+        "working tree は clean になりました。ブランチを切り替えられます",
+        "working tree is now clean — you can switch branches",
+    )
+}
+
+pub fn resume_success(locale: UiLocale, count: usize) -> String {
+    match locale {
+        UiLocale::Ja => format!("{count} 件の shadow changes を resume しました"),
+        UiLocale::En => format!("shadow changes resumed for {count} file(s)"),
+    }
+}
+
+pub fn resume_warning_no_suspended_content(locale: UiLocale, path: &str) -> String {
+    match locale {
+        UiLocale::Ja => format!("warning: {path} の suspended content がありません"),
+        UiLocale::En => format!("warning: no suspended content for {path}"),
+    }
+}
+
+pub fn resume_restored_file_absent_from_head(locale: UiLocale, path: &str) -> String {
+    match locale {
+        UiLocale::Ja => format!("{path}: shadow changes を戻しました (HEAD にファイルなし)"),
+        UiLocale::En => format!("{path}: shadow changes restored (file absent from HEAD)"),
+    }
+}
+
+pub fn resume_restored_shadow_changes(locale: UiLocale, path: &str) -> String {
+    match locale {
+        UiLocale::Ja => format!("{path}: shadow changes を戻しました"),
+        UiLocale::En => format!("{path}: shadow changes restored"),
+    }
+}
+
+pub fn resume_conflicts(locale: UiLocale, path: &str) -> String {
+    match locale {
+        UiLocale::Ja => {
+            format!("warning: {path} で conflict が発生しました。手動で解消してください")
+        }
+        UiLocale::En => format!("warning: conflicts detected in {path}. Please resolve manually"),
+    }
+}
+
+pub fn resume_merged(locale: UiLocale, path: &str) -> String {
+    match locale {
+        UiLocale::Ja => format!("{path}: baseline を更新し shadow changes を merge しました"),
+        UiLocale::En => format!("{path}: baseline updated and shadow changes merged"),
+    }
+}
+
+pub fn resume_phantom_restored(locale: UiLocale, path: &str) -> String {
+    match locale {
+        UiLocale::Ja => format!("{path}: phantom file を復元しました"),
+        UiLocale::En => format!("{path}: phantom file restored"),
+    }
+}
+
+pub fn rebase_no_overlay_files(locale: UiLocale) -> &'static str {
+    choose(
+        locale,
+        "overlay ファイルはありません",
+        "no overlay files found",
+    )
+}
+
+pub fn rebase_commit_ref_updated(locale: UiLocale, path: &str) -> String {
+    match locale {
+        UiLocale::Ja => format!("{path}: baseline の内容は同じでした (commit ref を更新)"),
+        UiLocale::En => format!("{path}: baseline content unchanged (commit ref updated)"),
+    }
+}
+
+pub fn rebase_conflicts(locale: UiLocale, path: &str) -> String {
+    match locale {
+        UiLocale::Ja => {
+            format!("warning: {path} で conflict が発生しました。手動で解消してください")
+        }
+        UiLocale::En => format!("warning: conflicts detected in {path}. Please resolve manually"),
+    }
+}
+
+pub fn rebase_updated(locale: UiLocale, path: &str) -> String {
+    match locale {
+        UiLocale::Ja => format!("{path} の baseline を更新しました"),
+        UiLocale::En => format!("baseline updated for {path}"),
+    }
+}
+
+pub fn baseline_outdated_warning(locale: UiLocale, path: &str) -> String {
+    match locale {
+        UiLocale::Ja => format!(
+            "warning: {path} の baseline は古くなっています。`git-shadow rebase {path}` を実行してください"
+        ),
+        UiLocale::En => format!(
+            "warning: baseline for {path} is outdated. Run `git-shadow rebase {path}`"
+        ),
+    }
+}
+
+pub fn post_commit_restore_failed(locale: UiLocale, path: &str, error: &str) -> String {
+    match locale {
+        UiLocale::Ja => format!("warning: {path} の復元に失敗しました: {error}"),
+        UiLocale::En => format!("warning: failed to restore {path}: {error}"),
+    }
+}
+
+pub fn post_commit_read_stash_failed(locale: UiLocale, path: &str, error: &str) -> String {
+    match locale {
+        UiLocale::Ja => format!("warning: {path} の stash 読み込みに失敗しました: {error}"),
+        UiLocale::En => format!("warning: failed to read stash for {path}: {error}"),
+    }
+}
+
+pub fn post_commit_partial_failure(locale: UiLocale) -> &'static str {
+    choose(
+        locale,
+        "warning: 復元できなかったファイルがあります。`git-shadow restore` を実行してください",
+        "warning: some files could not be restored. Run `git-shadow restore`",
+    )
+}
+
+pub fn doctor_all_checks_passed(locale: UiLocale) -> &'static str {
+    choose(
+        locale,
+        "すべてのチェックを通過しました",
+        "all checks passed",
+    )
+}
+
+pub fn doctor_issues_heading(locale: UiLocale) -> &'static str {
+    choose(locale, "issues:", "issues:")
+}
+
+pub fn doctor_warnings_heading(locale: UiLocale) -> &'static str {
+    choose(locale, "warnings:", "warnings:")
+}
+
+pub fn doctor_hook_missing(locale: UiLocale, hook: &str) -> String {
+    match locale {
+        UiLocale::Ja => format!("{hook} hook が存在しません"),
+        UiLocale::En => format!("{hook} hook does not exist"),
+    }
+}
+
+pub fn doctor_hook_not_executable(locale: UiLocale, hook: &str) -> String {
+    match locale {
+        UiLocale::Ja => format!("{hook} hook に実行権限がありません"),
+        UiLocale::En => format!("{hook} hook is not executable"),
+    }
+}
+
+pub fn doctor_hook_not_calling_shadow(locale: UiLocale, hook: &str) -> String {
+    match locale {
+        UiLocale::Ja => format!("{hook} hook が git-shadow を呼び出していません"),
+        UiLocale::En => format!("{hook} hook does not call git-shadow"),
+    }
+}
+
+pub fn doctor_competing_hook_manager(locale: UiLocale, marker: &str) -> String {
+    match locale {
+        UiLocale::Ja => format!("競合する hook manager を検出しました: {marker}"),
+        UiLocale::En => format!("competing hook manager detected: {marker}"),
+    }
+}
+
+pub fn doctor_overlay_missing_worktree(locale: UiLocale, path: &str) -> String {
+    match locale {
+        UiLocale::Ja => format!("{path} が working tree に存在しません"),
+        UiLocale::En => format!("{path} does not exist in working tree"),
+    }
+}
+
+pub fn doctor_baseline_missing(locale: UiLocale, path: &str) -> String {
+    match locale {
+        UiLocale::Ja => format!("{path} の baseline file が存在しません"),
+        UiLocale::En => format!("baseline file for {path} does not exist"),
+    }
+}
+
+pub fn doctor_phantom_dir_missing(locale: UiLocale, path: &str) -> String {
+    match locale {
+        UiLocale::Ja => format!("{path} (phantom dir) が working tree に存在しません"),
+        UiLocale::En => format!("{path} (phantom dir) does not exist in working tree"),
+    }
+}
+
+pub fn doctor_phantom_missing(locale: UiLocale, path: &str) -> String {
+    match locale {
+        UiLocale::Ja => format!("{path} (phantom) が working tree に存在しません"),
+        UiLocale::En => format!("{path} (phantom) does not exist in working tree"),
+    }
+}
+
+pub fn doctor_stash_remaining(locale: UiLocale) -> &'static str {
+    choose(
+        locale,
+        "stash に残りファイルがあります。`git-shadow restore` を実行してください",
+        "stash has remaining files. Run `git-shadow restore`",
+    )
+}
+
+pub fn doctor_suspended(locale: UiLocale) -> &'static str {
+    choose(
+        locale,
+        "shadow changes は suspend 中です。`git-shadow resume` を実行してください",
+        "shadow changes are suspended. Run `git-shadow resume`",
+    )
+}
+
+pub fn doctor_suspended_dir_missing(locale: UiLocale) -> &'static str {
+    choose(
+        locale,
+        "suspended directory がありません (状態が壊れている可能性があります)",
+        "suspended directory is missing (state may be corrupted)",
+    )
+}
+
+pub fn doctor_worktree_not_initialized(locale: UiLocale) -> &'static str {
+    choose(
+        locale,
+        "worktree を検出しましたが、この worktree では git-shadow が未初期化です。`git-shadow install` を実行してください",
+        "worktree detected but git-shadow is not initialized here. Run `git-shadow install` to set up this worktree",
+    )
+}
+
+pub fn doctor_worktree_no_config(locale: UiLocale) -> &'static str {
+    choose(
+        locale,
+        "worktree を検出しましたが shadow config がありません。`git-shadow add <file>` でこの worktree のファイルを登録してください",
+        "worktree detected but no shadow config found. Run `git-shadow add <file>` to register files in this worktree",
+    )
+}
+
+pub fn doctor_stale_lock(locale: UiLocale, pid: u32) -> String {
+    match locale {
+        UiLocale::Ja => format!(
+            "stale lockfile を検出しました (PID {pid})。`git-shadow restore` を実行してください"
+        ),
+        UiLocale::En => format!("stale lockfile detected (PID {pid}). Run `git-shadow restore`"),
+    }
+}
+
+pub fn doctor_lock_held(locale: UiLocale, pid: u32) -> String {
+    match locale {
+        UiLocale::Ja => format!("lockfile は別プロセス (PID {pid}) が保持しています"),
+        UiLocale::En => format!("lockfile is held by another process (PID {pid})"),
+    }
+}
+
+pub fn status_warning_stash_remaining(locale: UiLocale) -> &'static str {
+    choose(
+        locale,
+        "  warning: stash に残りファイルがあります (前回の commit が中断された可能性があります)",
+        "  warning: stash has remaining files (a previous commit may have been interrupted)",
+    )
+}
+
+pub fn status_warning_stale_lock(locale: UiLocale, pid: u32) -> String {
+    match locale {
+        UiLocale::Ja => {
+            format!("  warning: stale lockfile を検出しました (PID {pid} は既に存在しません)")
+        }
+        UiLocale::En => {
+            format!("  warning: stale lockfile detected (PID {pid} no longer exists)")
+        }
+    }
+}
+
+pub fn status_action_run_restore(locale: UiLocale) -> &'static str {
+    choose(
+        locale,
+        "    -> `git-shadow restore` を実行",
+        "    -> Run `git-shadow restore`",
+    )
+}
+
+pub fn status_suspended(locale: UiLocale) -> &'static str {
+    choose(
+        locale,
+        "  status: SUSPENDED (`git-shadow resume` で shadow changes を戻します)",
+        "  status: SUSPENDED (run `git-shadow resume` to restore shadow changes)",
+    )
+}
+
+pub fn status_heading_managed_files(locale: UiLocale) -> &'static str {
+    choose(locale, "managed files:", "managed files:")
+}
+
+pub fn label_overlay(locale: UiLocale) -> &'static str {
+    choose(locale, "overlay", "overlay")
+}
+
+pub fn label_phantom(locale: UiLocale) -> &'static str {
+    choose(locale, "phantom", "phantom")
+}
+
+pub fn label_phantom_dir(locale: UiLocale) -> &'static str {
+    choose(locale, "phantom dir", "phantom dir")
+}
+
+pub fn status_baseline(locale: UiLocale, commit: &str) -> String {
+    match locale {
+        UiLocale::Ja => format!("    baseline: {commit}"),
+        UiLocale::En => format!("    baseline: {commit}"),
+    }
+}
+
+pub fn status_warning_file_missing_worktree(locale: UiLocale) -> &'static str {
+    choose(
+        locale,
+        "    warning: file が working tree に存在しません",
+        "    warning: file does not exist in working tree",
+    )
+}
+
+pub fn status_shadow_changes(locale: UiLocale, added: usize, removed: usize) -> String {
+    match locale {
+        UiLocale::Ja => format!("    shadow changes: +{added} 行 / -{removed} 行"),
+        UiLocale::En => format!("    shadow changes: +{added} lines / -{removed} lines"),
+    }
+}
+
+pub fn status_warning_baseline_outdated(
+    locale: UiLocale,
+    old_commit: &str,
+    new_commit: &str,
+) -> String {
+    match locale {
+        UiLocale::Ja => {
+            format!("    warning: baseline が古くなっています ({old_commit} -> {new_commit})")
+        }
+        UiLocale::En => {
+            format!("    warning: baseline is outdated ({old_commit} -> {new_commit})")
+        }
+    }
+}
+
+pub fn status_action_run_rebase(locale: UiLocale, path: &str) -> String {
+    match locale {
+        UiLocale::Ja => format!("    -> `git-shadow rebase {path}` を実行"),
+        UiLocale::En => format!("    -> Run `git-shadow rebase {path}`"),
+    }
+}
+
+pub fn status_exclude_git_info(locale: UiLocale) -> &'static str {
+    choose(
+        locale,
+        "    exclude: .git/info/exclude",
+        "    exclude: .git/info/exclude",
+    )
+}
+
+pub fn status_exclude_none(locale: UiLocale) -> &'static str {
+    choose(
+        locale,
+        "    exclude: なし (hook 保護のみ)",
+        "    exclude: none (hook protection only)",
+    )
+}
+
+pub fn status_contents(locale: UiLocale, count: usize) -> String {
+    match locale {
+        UiLocale::Ja => format!("    contents: {count} entries"),
+        UiLocale::En => format!("    contents: {count} entries"),
+    }
+}
+
+pub fn status_warning_directory_missing(locale: UiLocale) -> &'static str {
+    choose(
+        locale,
+        "    warning: directory が存在しません",
+        "    warning: directory does not exist",
+    )
+}
+
+pub fn status_warning_file_missing(locale: UiLocale) -> &'static str {
+    choose(
+        locale,
+        "    warning: file が存在しません",
+        "    warning: file does not exist",
+    )
+}
+
+pub fn status_file_size(locale: UiLocale, size: &str) -> String {
+    match locale {
+        UiLocale::Ja => format!("    file size: {size}"),
+        UiLocale::En => format!("    file size: {size}"),
+    }
+}
+
+fn choose(locale: UiLocale, ja: &'static str, en: &'static str) -> &'static str {
+    match locale {
+        UiLocale::Ja => ja,
+        UiLocale::En => en,
+    }
+}
+
+fn find_shadow_error(err: &anyhow::Error) -> Option<&ShadowError> {
+    err.chain()
+        .find_map(|cause| cause.downcast_ref::<ShadowError>())
+}
+
+fn format_shadow_error(err: &ShadowError, locale: UiLocale) -> String {
+    match locale {
+        UiLocale::Ja => format_shadow_error_ja(err),
+        UiLocale::En => format_shadow_error_en(err),
+    }
+}
+
+fn format_shadow_error_ja(err: &ShadowError) -> String {
+    match err {
+        ShadowError::NotAGitRepo => "エラー: Git リポジトリではありません".to_string(),
+        ShadowError::FileNotTracked(path) => {
+            format!("エラー: `{path}` は Git に追跡されていません")
+        }
+        ShadowError::AlreadyManaged(path) => {
+            format!("エラー: `{path}` は既に git-shadow の管理対象です")
+        }
+        ShadowError::NotManaged(path) => {
+            format!("エラー: `{path}` は git-shadow の管理対象ではありません")
+        }
+        ShadowError::BinaryFile(path) => {
+            format!("エラー: `{path}` はバイナリファイルです")
+        }
+        ShadowError::FileTooLarge(path, size, limit) => format!(
+            "エラー: `{path}` がサイズ制限を超えています ({size} bytes > {limit} bytes)。`--force` を使ってください"
+        ),
+        ShadowError::PartialStage(file) => format!(
+            "コミットを止めました: shadow 管理中の `{file}` が部分的に stage されています。\n\
+             対処:\n\
+             1. `git add {file}` でファイル全体を stage し直す\n\
+             2. もう一度 `git commit` する"
+        ),
+        ShadowError::Suspended => "\
+コミットを止めました: shadow changes が suspend されたままです。\n\
+対処:\n\
+1. `git-shadow resume` を実行して shadow changes を戻す\n\
+2. 必要なら内容を確認してから `git commit` をやり直す"
+            .to_string(),
+        ShadowError::StashRemaining => "\
+コミットを止めました: 前回の commit 処理の残骸が `.git/shadow/stash/` に残っています。\n\
+対処:\n\
+1. `git-shadow restore` を実行して stash と lock を回復する\n\
+2. `git status` で作業ツリーを確認する\n\
+3. もう一度 `git commit` する"
+            .to_string(),
+        ShadowError::BaselineMissing(file) => format!(
+            "コミットを止めました: `{file}` の baseline が見つかりません。\n\
+             対処:\n\
+             1. `{file}` の現在内容を残したいなら先に別の場所へ退避する\n\
+             2. `git-shadow remove --force {file}` で登録を外す\n\
+             3. `git-shadow add {file}` で登録し直し、必要なら local changes を戻す"
+        ),
+        ShadowError::FileMissing(file) => format!(
+            "コミットを止めました: overlay 管理中の `{file}` が作業ツリーにありません。\n\
+             対処:\n\
+             1. 誤って消したなら `git restore --source=HEAD -- {file}` で戻す\n\
+             2. もう管理しないなら `git-shadow remove --force {file}` を実行する\n\
+             3. その後でもう一度 `git commit` する"
+        ),
+        ShadowError::UnstageFailure(file) => format!(
+            "コミットを止めました: phantom の `{file}` を index から外せませんでした。\n\
+             対処:\n\
+             1. `git reset -- {file}` を実行する\n\
+             2. `git status` で stage 状態を確認する\n\
+             3. もう一度 `git commit` する"
+        ),
+        ShadowError::LockHeld { pid, timestamp } => format!(
+            "コミットを止めました: 別の git-shadow 処理が lock を保持しています。\n\
+             詳細: PID {pid}, started: {timestamp}\n\
+             対処:\n\
+             1. その commit / hook 処理が終わるまで待つ\n\
+             2. もし既に止まっているはずなら `git-shadow restore` を実行する\n\
+             3. その後で `git commit` をやり直す"
+        ),
+        ShadowError::StaleLock(pid) => format!(
+            "コミットを止めました: stale lock が残っています。\n\
+             詳細: PID {pid} は既に存在しません。\n\
+             対処:\n\
+             1. `git-shadow restore` を実行して lock を片付ける\n\
+             2. `git status` を確認する\n\
+             3. もう一度 `git commit` する"
+        ),
+        ShadowError::NotInitialized => "\
+エラー: git-shadow がまだ初期化されていません。\n\
+対処:\n\
+1. リポジトリで `git-shadow install` を実行する\n\
+2. その後に `git-shadow add ...` や `git commit` をやり直す"
+            .to_string(),
+        ShadowError::AlreadySuspended => {
+            "エラー: shadow changes は既に suspend されています".to_string()
+        }
+        ShadowError::NotSuspended => {
+            "エラー: shadow changes は suspend されていません".to_string()
+        }
+        ShadowError::HooksNotInstalled => {
+            "エラー: hooks が未インストールです。`git-shadow install` を実行してください"
+                .to_string()
+        }
+        ShadowError::NonInteractiveWithoutForce => {
+            "エラー: 非対話モードでは `--force` が必要です".to_string()
+        }
+        ShadowError::GitCommand { command, stderr } => {
+            format!("エラー: Git コマンドに失敗しました: {command}\n{stderr}")
+        }
+        _ => format!("エラー: {}", err),
+    }
+}
+
+fn format_shadow_error_en(err: &ShadowError) -> String {
+    match err {
+        ShadowError::NotAGitRepo => "Error: not a Git repository".to_string(),
+        ShadowError::FileNotTracked(path) => {
+            format!("Error: `{path}` is not tracked by Git")
+        }
+        ShadowError::AlreadyManaged(path) => {
+            format!("Error: `{path}` is already managed by git-shadow")
+        }
+        ShadowError::NotManaged(path) => {
+            format!("Error: `{path}` is not managed by git-shadow")
+        }
+        ShadowError::BinaryFile(path) => format!("Error: `{path}` is a binary file"),
+        ShadowError::FileTooLarge(path, size, limit) => format!(
+            "Error: `{path}` exceeds the size limit ({size} bytes > {limit} bytes). Use `--force` to override"
+        ),
+        ShadowError::PartialStage(file) => format!(
+            "Commit blocked: `{file}` is partially staged while managed by git-shadow.\n\
+             What to do:\n\
+             1. Run `git add {file}` to stage the whole file\n\
+             2. Run `git commit` again"
+        ),
+        ShadowError::Suspended => "\
+Commit blocked: shadow changes are still suspended.\n\
+What to do:\n\
+1. Run `git-shadow resume`\n\
+2. Review the restored changes if needed\n\
+3. Run `git commit` again"
+            .to_string(),
+        ShadowError::StashRemaining => "\
+Commit blocked: leftover files remain in `.git/shadow/stash/` from an earlier interrupted commit.\n\
+What to do:\n\
+1. Run `git-shadow restore`\n\
+2. Check `git status`\n\
+3. Run `git commit` again"
+            .to_string(),
+        ShadowError::BaselineMissing(file) => format!(
+            "Commit blocked: the baseline for `{file}` is missing.\n\
+             What to do:\n\
+             1. Save a copy first if you need the current contents\n\
+             2. Run `git-shadow remove --force {file}`\n\
+             3. Run `git-shadow add {file}` and re-apply your local-only edits if needed"
+        ),
+        ShadowError::FileMissing(file) => format!(
+            "Commit blocked: overlay-managed file `{file}` is missing from the working tree.\n\
+             What to do:\n\
+             1. If you deleted it by accident, run `git restore --source=HEAD -- {file}`\n\
+             2. If you no longer want it managed, run `git-shadow remove --force {file}`\n\
+             3. Run `git commit` again"
+        ),
+        ShadowError::UnstageFailure(file) => format!(
+            "Commit blocked: git-shadow could not unstage phantom file `{file}`.\n\
+             What to do:\n\
+             1. Run `git reset -- {file}`\n\
+             2. Check `git status`\n\
+             3. Run `git commit` again"
+        ),
+        ShadowError::LockHeld { pid, timestamp } => format!(
+            "Commit blocked: another git-shadow process still holds the lock.\n\
+             Details: PID {pid}, started: {timestamp}\n\
+             What to do:\n\
+             1. Wait for the other commit or hook to finish\n\
+             2. If it should already be done, run `git-shadow restore`\n\
+             3. Run `git commit` again"
+        ),
+        ShadowError::StaleLock(pid) => format!(
+            "Commit blocked: a stale lock was found.\n\
+             Details: PID {pid} no longer exists.\n\
+             What to do:\n\
+             1. Run `git-shadow restore`\n\
+             2. Check `git status`\n\
+             3. Run `git commit` again"
+        ),
+        ShadowError::NotInitialized => "\
+Error: git-shadow is not initialized yet.\n\
+What to do:\n\
+1. Run `git-shadow install` in this repository\n\
+2. Retry `git-shadow add ...` or `git commit`"
+            .to_string(),
+        ShadowError::AlreadySuspended => {
+            "Error: shadow changes are already suspended".to_string()
+        }
+        ShadowError::NotSuspended => "Error: shadow changes are not suspended".to_string(),
+        ShadowError::HooksNotInstalled => {
+            "Error: hooks not installed. Run `git-shadow install`".to_string()
+        }
+        ShadowError::NonInteractiveWithoutForce => {
+            "Error: `--force` is required in non-interactive mode".to_string()
+        }
+        ShadowError::GitCommand { command, stderr } => {
+            format!("Error: git command failed: {command}\n{stderr}")
+        }
+        _ => format!("Error: {}", err),
+    }
+}
+
+fn detect_locale_from_values(values: impl IntoIterator<Item = String>) -> UiLocale {
+    for value in values {
+        let normalized = value.to_ascii_lowercase();
+        if normalized.starts_with("ja") {
+            return UiLocale::Ja;
+        }
+        if normalized.starts_with("en") {
+            return UiLocale::En;
+        }
+    }
+
+    UiLocale::En
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_detect_locale_defaults_to_en() {
+        let locale = detect_locale_from_values(Vec::<String>::new());
+        assert_eq!(locale, UiLocale::En);
+    }
+
+    #[test]
+    fn test_detect_locale_prefers_ja() {
+        let locale = detect_locale_from_values(vec!["ja_JP.UTF-8".to_string()]);
+        assert_eq!(locale, UiLocale::Ja);
+    }
+
+    #[test]
+    fn test_format_error_ja_for_partial_stage() {
+        let err = anyhow::Error::new(ShadowError::PartialStage("tracked.txt".to_string()));
+        let message = format_error(&err, UiLocale::Ja);
+        assert!(message.contains("コミットを止めました"));
+        assert!(message.contains("git add tracked.txt"));
+    }
+
+    #[test]
+    fn test_format_error_en_for_stash_remaining() {
+        let err = anyhow::Error::new(ShadowError::StashRemaining);
+        let message = format_error(&err, UiLocale::En);
+        assert!(message.contains("Commit blocked"));
+        assert!(message.contains("git-shadow restore"));
+    }
+}

--- a/tests/test_localized_errors.rs
+++ b/tests/test_localized_errors.rs
@@ -1,0 +1,138 @@
+use std::path::Path;
+use std::process::Command;
+
+fn init_repo() -> tempfile::TempDir {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+
+    run_git(root, &["init"]);
+    run_git(root, &["config", "user.name", "Test"]);
+    run_git(root, &["config", "user.email", "test@example.com"]);
+    std::fs::write(root.join("tracked.txt"), "base\n").unwrap();
+    run_git(root, &["add", "tracked.txt"]);
+    run_git(root, &["commit", "-m", "init"]);
+
+    dir
+}
+
+fn run_git(root: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(root)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "git {} failed: {}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn run_git_shadow(
+    root: &Path,
+    bin_dir: &Path,
+    locale: &str,
+    args: &[&str],
+) -> std::process::Output {
+    let path = prepend_path(bin_dir);
+    Command::new("git-shadow")
+        .args(args)
+        .current_dir(root)
+        .env("PATH", path)
+        .env("LANG", locale)
+        .output()
+        .unwrap()
+}
+
+fn prepend_path(bin_dir: &Path) -> String {
+    let current = std::env::var_os("PATH").unwrap_or_default();
+    let mut paths = vec![bin_dir.to_path_buf()];
+    paths.extend(std::env::split_paths(&current));
+    std::env::join_paths(paths)
+        .unwrap()
+        .to_string_lossy()
+        .into_owned()
+}
+
+#[test]
+fn test_not_initialized_message_is_english_for_english_locale() {
+    let repo = init_repo();
+    let bin = assert_cmd::cargo::cargo_bin!("git-shadow");
+    let bin_dir = bin.parent().unwrap();
+
+    let output = run_git_shadow(repo.path(), bin_dir, "en_US.UTF-8", &["add", "tracked.txt"]);
+    assert!(!output.status.success());
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("git-shadow is not initialized yet"));
+    assert!(stderr.contains("git-shadow install"));
+}
+
+#[test]
+fn test_partial_stage_message_is_japanese_for_japanese_locale() {
+    let repo = init_repo();
+    let bin = assert_cmd::cargo::cargo_bin!("git-shadow");
+    let bin_dir = bin.parent().unwrap();
+
+    let install = run_git_shadow(repo.path(), bin_dir, "ja_JP.UTF-8", &["install"]);
+    assert!(install.status.success());
+
+    let add = run_git_shadow(repo.path(), bin_dir, "ja_JP.UTF-8", &["add", "tracked.txt"]);
+    assert!(add.status.success());
+
+    std::fs::write(repo.path().join("tracked.txt"), "base\nline1\nline2\n").unwrap();
+    run_git(repo.path(), &["add", "tracked.txt"]);
+    std::fs::write(
+        repo.path().join("tracked.txt"),
+        "base\nline1\nline2\nline3\n",
+    )
+    .unwrap();
+
+    let output = Command::new("git")
+        .args(["commit", "-m", "partial"])
+        .current_dir(repo.path())
+        .env("PATH", prepend_path(bin_dir))
+        .env("LANG", "ja_JP.UTF-8")
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("コミットを止めました"));
+    assert!(stderr.contains("git add tracked.txt"));
+}
+
+#[test]
+fn test_help_is_japanese_for_japanese_locale() {
+    let repo = init_repo();
+    let bin = assert_cmd::cargo::cargo_bin!("git-shadow");
+    let bin_dir = bin.parent().unwrap();
+
+    let output = run_git_shadow(repo.path(), bin_dir, "ja_JP.UTF-8", &["--help"]);
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Git リポジトリ内のローカル専用変更を管理します"));
+    assert!(stdout.contains("管理対象ファイルと状態を表示する"));
+}
+
+#[test]
+fn test_status_is_english_for_english_locale() {
+    let repo = init_repo();
+    let bin = assert_cmd::cargo::cargo_bin!("git-shadow");
+    let bin_dir = bin.parent().unwrap();
+
+    let install = run_git_shadow(repo.path(), bin_dir, "en_US.UTF-8", &["install"]);
+    assert!(install.status.success());
+    let add = run_git_shadow(repo.path(), bin_dir, "en_US.UTF-8", &["add", "tracked.txt"]);
+    assert!(add.status.success());
+
+    let output = run_git_shadow(repo.path(), bin_dir, "en_US.UTF-8", &["status"]);
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("managed files:"));
+    assert!(stdout.contains("shadow changes: +0 lines / -0 lines"));
+}


### PR DESCRIPTION
## Summary
- add a locale-aware UI layer for runtime output and commit-blocking guidance
- localize user-facing CLI output, hook warnings, and `--help` text for Japanese and English users
- harden path normalization and initialization checks to reject out-of-repo paths and surface clearer setup errors

## Why
- users were seeing English-only output even when the intended audience was Japanese
- commit-blocking cases needed actionable, language-appropriate recovery guidance
- manual repo testing exposed unsafe path handling and confusing pre-install failures that should be fixed alongside the localization work

## User impact
- Japanese users now see Japanese help, status output, doctor output, and hook/error guidance
- English users keep English output, including commit-blocking instructions
- `git-shadow add` now rejects paths that resolve outside the repository and tells users to run `git-shadow install` before add flows that need shadow state

## Validation
- `cargo test`
- manual spot checks for `LANG=ja_JP.UTF-8 git-shadow --help`
- manual spot checks for `LANG=en_US.UTF-8 git-shadow status`
- manual `git commit` hook failure with Japanese localized guidance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added locale-aware UI with Japanese and English language support throughout the application.
  * Enhanced error messages with detailed, localized context.
  * Improved path handling with better validation and repository boundary checks.
  * CLI now supports locale-aware help and command-line parsing.

* **Bug Fixes**
  * Strengthened path validation to reject paths that escape the repository.
  * Improved initialization checks across commands.

* **Tests**
  * Added comprehensive locale-aware integration tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->