### PR TITLE
[codex] Improve git-shadow UX for daily Git flow

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -48,13 +48,16 @@ cargo install --path .
 cd your-repo
 git-shadow install
 
-# overlay を追加（既存のトラッキング済みファイル）
+# 管理対象を追加（tracked は overlay、existing untracked は phantom を自動判定）
 git-shadow add docker-compose.yml
+git-shadow add scripts/local-setup.sh
 echo "  # 個人用デバッグポート" >> docker-compose.yml
 
-# phantom を追加（新規ローカル限定ファイル）
-echo "#!/bin/bash" > scripts/local-setup.sh
-git-shadow add --phantom scripts/local-setup.sh
+# 明示的に phantom / overlay を強制したい場合はフラグも使える
+git-shadow add --phantom another-local-file.sh
+
+# Git の状態と shadow の意味をまとめて確認
+git shadow status --git
 
 # 普通にコミット — shadow 変更は自動的に除外される
 git add -A && git commit -m "チームの変更"
@@ -68,11 +71,11 @@ git show HEAD:docker-compose.yml  # クリーンなチーム用の内容のみ
 
 | コマンド | 説明 |
 |---------|------|
-| `git-shadow install` | Git hooks のセットアップ (pre-commit, post-commit, post-merge) |
-| `git-shadow add <file>` | トラッキング済みファイルを overlay として登録 |
-| `git-shadow add --phantom <file>` | ローカル限定ファイルを phantom として登録 |
+| `git-shadow install` | Git hooks のセットアップ (pre-commit, post-commit, post-merge, post-rewrite) |
+| `git-shadow add <file>...` | tracked は overlay、既存の untracked path は phantom として自動登録 |
+| `git-shadow add --phantom <file>...` | ローカル限定ファイル/ディレクトリを phantom として強制登録 |
 | `git-shadow remove <file>` | shadow 管理から解除 |
-| `git-shadow status` | 管理対象ファイルの一覧と状態を表示 |
+| `git-shadow status [--git]` | 管理対象ファイルの一覧と状態を表示。`--git` で `git status --short --branch` も先に表示 |
 | `git-shadow diff [file]` | shadow 変更の差分を表示 |
 | `git-shadow rebase [file]` | ベースラインを更新し shadow 変更を再適用 (3-way merge) |
 | `git-shadow restore [file]` | 中断されたコミットやクラッシュからの復旧 |
@@ -96,6 +99,12 @@ git show HEAD:docker-compose.yml  # クリーンなチーム用の内容のみ
 - **ロックファイル**: PID ベースのロックで並行操作を防止
 - **ロールバック**: pre-commit の失敗時は自動的にロールバック
 - **リカバリ**: `git-shadow restore` であらゆる中断状態から復旧可能
+- **自動回復**: stale lock は安全に直せる場合だけ自動回復し、上書きリスクがある場合は手動復旧を要求
+
+## 日常運用のメモ
+
+- デフォルトでは `git status` 自体は置き換えません。opt-in の統合表示として `git shadow status --git` を使ってください。
+- Git には一般的な pre-`add` hook がないため、overlay への早期警告は `git-shadow status` と commit 時の警告で補います。
 
 ## ドキュメント
 

--- a/README.md
+++ b/README.md
@@ -48,13 +48,16 @@ cargo install --path .
 cd your-repo
 git-shadow install
 
-# Add an overlay (existing tracked file)
+# Add managed files (tracked => overlay, untracked => phantom)
 git-shadow add docker-compose.yml
+git-shadow add scripts/local-setup.sh
 echo "  # my debug port override" >> docker-compose.yml
 
-# Add a phantom (new local-only file)
-echo "#!/bin/bash" > scripts/local-setup.sh
-git-shadow add --phantom scripts/local-setup.sh
+# If you want to force phantom/overlay explicitly, the old flags still work
+git-shadow add --phantom another-local-file.sh
+
+# Inspect normal Git state plus shadow meaning
+git shadow status --git
 
 # Commit as usual — shadow changes are automatically excluded
 git add -A && git commit -m "team changes"
@@ -68,11 +71,11 @@ git show HEAD:docker-compose.yml  # clean, team-only content
 
 | Command | Description |
 |---------|-------------|
-| `git-shadow install` | Set up Git hooks (pre-commit, post-commit, post-merge) |
-| `git-shadow add <file>` | Register a tracked file as an overlay |
-| `git-shadow add --phantom <file>` | Register a local-only file as a phantom |
+| `git-shadow install` | Set up Git hooks (pre-commit, post-commit, post-merge, post-rewrite) |
+| `git-shadow add <file>...` | Register tracked files as overlays and existing untracked paths as phantoms automatically |
+| `git-shadow add --phantom <file>...` | Force local-only files/directories to be phantoms |
 | `git-shadow remove <file>` | Unregister a file from shadow management |
-| `git-shadow status` | Show managed files and their state |
+| `git-shadow status [--git]` | Show managed files and their state, optionally prefixed by `git status --short --branch` |
 | `git-shadow diff [file]` | Show shadow changes as a unified diff |
 | `git-shadow rebase [file]` | Update baseline after upstream changes (3-way merge) |
 | `git-shadow restore [file]` | Recover from interrupted commits or crashes |
@@ -96,6 +99,12 @@ All data is stored in `.git/shadow/` — inside `.git/`, so it's never committed
 - **Lockfile**: PID-based lock prevents concurrent operations
 - **Rollback**: Failed pre-commit operations are rolled back automatically
 - **Recovery**: `git-shadow restore` recovers from any interrupted state
+- **Auto-healing**: stale locks are recovered automatically when doing so is safe; ambiguous cases still stop and ask for manual restore
+
+## Daily Flow Notes
+
+- `git status` itself is not replaced by default. Use `git shadow status --git` if you want an opt-in combined view.
+- Git does not provide a general pre-`add` hook, so early warnings for overlay files happen in `git-shadow status` and at commit time, not during `git add`.
 
 ## Documentation
 

--- a/docs/usage.ja.md
+++ b/docs/usage.ja.md
@@ -58,12 +58,14 @@ echo "  # 個人用デバッグポート" >> docker-compose.yml
 ```bash
 # 新しいローカル限定ファイルを作成して登録
 echo "#!/bin/bash" > scripts/local-setup.sh
-git-shadow add --phantom scripts/local-setup.sh
+git-shadow add scripts/local-setup.sh
 ```
 
 デフォルトでは `.git/info/exclude` に追加され、`git status` に表示されなくなります。
 
 **オプション:**
+- `--overlay` — 指定したパスをすべて overlay として強制登録
+- `--phantom` — 指定したパスをすべて phantom として強制登録
 - `--no-exclude` — `.git/info/exclude` への追加をスキップ。`git status` には未追跡ファイルとして表示されますが、pre-commit hook によりコミットからは除外されます。
 
 #### Phantom ディレクトリ
@@ -101,8 +103,18 @@ git-shadow status
 
 管理対象ファイルの情報を表示:
 - Overlay: ベースラインのコミットハッシュ、差分行数 (+/- 行)
+- Overlay: 現在の Git 状態 (`clean`, `modified`, `staged`, `partially staged`)
+- Overlay: stage 済み local-only changes が commit 前に取り除かれる警告
 - Phantom: exclude モード、ファイルサイズ
 - stale lock、stash 残留、ベースラインずれの警告
+
+通常の Git 出力も含めた opt-in 表示を使いたい場合:
+
+```bash
+git shadow status --git
+```
+
+`git status --short --branch` を先に表示し、その後に shadow 管理対象の意味づけを表示します。デフォルトでは `git status` 自体は置き換えません。
 
 ### Diff
 
@@ -221,6 +233,8 @@ git-shadow restore docker-compose.yml
 - 退避ファイルをワーキングツリーに復元
 - stale lockfile を削除
 - stash ディレクトリをクリーンアップ
+
+`git commit` 中に stale lock が見つかった場合も、作業ツリーを安全に復元できると判断できるときは自動回復を試みます。新しい内容を上書きする恐れがある場合だけ、従来どおり手動 `git-shadow restore` が必要です。
 
 ## 診断
 
@@ -353,6 +367,14 @@ worktree を使う場合、suspend/resume は不要です（各 worktree が独�
 ### 部分ステージ
 
 git-shadow は overlay ファイルの部分ステージ (`git add -p`) をサポートしていません。overlay ファイルにステージ済みと未ステージの変更が同時に存在する場合、pre-commit hook がコミットをブロックします。コミット前に `git add <file>` でファイル全体をステージしてください。
+
+### `git add` 時のガード
+
+Git には一般的な pre-`add` hook がないため、git-shadow はすべての `git add` の直前には警告できません。代わりに:
+
+- `git-shadow status` で overlay が local-only かつ stage 済みかを表示します
+- `git shadow status --git` で通常の Git 状態を含む opt-in 表示を使えます
+- pre-commit hook が local-only な overlay 変更が取り除かれることを警告します
 
 ### バイナリファイル
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -58,12 +58,14 @@ Use phantoms for files that should exist only on your machine.
 ```bash
 # Create and register a new local-only file
 echo "#!/bin/bash" > scripts/local-setup.sh
-git-shadow add --phantom scripts/local-setup.sh
+git-shadow add scripts/local-setup.sh
 ```
 
 By default, phantom files are added to `.git/info/exclude` to hide them from `git status`.
 
 **Options:**
+- `--overlay` — Force overlay registration for all given paths
+- `--phantom` — Force phantom registration for all given paths
 - `--no-exclude` — Skip the `.git/info/exclude` entry. The file will appear in `git status` as untracked but will still be excluded from commits by the pre-commit hook.
 
 #### Phantom Directories
@@ -101,8 +103,18 @@ git-shadow status
 
 Shows all managed files with:
 - Overlay: baseline commit hash, diff line counts (+/- lines)
+- Overlay: current Git state (`clean`, `modified`, `staged`, or `partially staged`)
+- Overlay: a local-only warning when staged changes will be stripped at commit time
 - Phantom: exclude mode, file size
 - Warnings for stale locks, stash remnants, or baseline drift
+
+For an opt-in combined view with normal Git output:
+
+```bash
+git shadow status --git
+```
+
+This prints `git status --short --branch` first, then the shadow-managed summary. `git-shadow` does not replace `git status` by default.
 
 ### Diff
 
@@ -221,6 +233,8 @@ git-shadow restore docker-compose.yml
 - Restores stashed files to the working tree
 - Removes stale lockfiles
 - Cleans up the stash directory
+
+When a stale lock is found during `git commit`, git-shadow also tries safe auto-recovery first. If restoring would overwrite newer working-tree content, the commit is still blocked and manual `git-shadow restore` is required.
 
 ## Diagnostics
 
@@ -353,6 +367,14 @@ Using `--no-verify` skips the pre-commit hook, so shadow changes will be include
 ### Partial Staging
 
 git-shadow does not support partial staging (`git add -p`) of overlay files. If both staged and unstaged changes exist for an overlay file, the pre-commit hook will block the commit. Stage the entire file with `git add <file>` before committing.
+
+### `git add` Guardrails
+
+Git does not provide a general pre-`add` hook, so git-shadow cannot warn before every `git add`. Instead:
+
+- `git-shadow status` shows when overlay-managed files are local-only and currently staged
+- `git shadow status --git` gives an opt-in daily wrapper view with normal Git status first
+- the pre-commit hook warns when staged local-only overlay changes are about to be stripped
 
 ### Binary Files
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -19,8 +19,11 @@ pub enum Commands {
 
     /// Register a file for shadow management
     Add {
-        /// Target file path
-        file: String,
+        /// Target file paths
+        files: Vec<String>,
+        /// Register as overlay even if auto-detection would choose phantom
+        #[arg(long, conflicts_with = "phantom")]
+        overlay: bool,
         /// Register as a phantom (local-only file)
         #[arg(long)]
         phantom: bool,
@@ -42,7 +45,11 @@ pub enum Commands {
     },
 
     /// Show managed files and their status
-    Status,
+    Status {
+        /// Show `git status --short --branch` before the shadow summary
+        #[arg(long)]
+        git: bool,
+    },
 
     /// Show shadow changes as a diff
     Diff {
@@ -74,7 +81,7 @@ pub enum Commands {
     /// Internal subcommand called from hooks
     #[command(hide = true)]
     Hook {
-        /// Hook name (pre-commit, post-commit, post-merge)
+        /// Hook name (pre-commit, post-commit, post-merge, post-rewrite)
         hook_name: String,
     },
 }
@@ -113,16 +120,22 @@ fn localize_subcommands(command: clap::Command, locale: UiLocale) -> clap::Comma
             UiLocale::Ja => "ファイルを shadow 管理に登録する",
             UiLocale::En => "Register a file for shadow management",
         })
-        .mut_arg("file", |arg| {
+        .mut_arg("files", |arg| {
             arg.help(match locale {
-                UiLocale::Ja => "対象ファイルのパス",
-                UiLocale::En => "Target file path",
+                UiLocale::Ja => "対象ファイルのパス (複数指定可)",
+                UiLocale::En => "Target file paths (multiple allowed)",
+            })
+        })
+        .mut_arg("overlay", |arg| {
+            arg.help(match locale {
+                UiLocale::Ja => "overlay として強制登録する",
+                UiLocale::En => "Force overlay registration",
             })
         })
         .mut_arg("phantom", |arg| {
             arg.help(match locale {
-                UiLocale::Ja => "phantom (ローカル専用ファイル) として登録する",
-                UiLocale::En => "Register as a phantom (local-only file)",
+                UiLocale::Ja => "phantom (ローカル専用ファイル) として強制登録する",
+                UiLocale::En => "Force phantom registration",
             })
         })
         .mut_arg("no_exclude", |arg| {
@@ -160,6 +173,12 @@ fn localize_subcommands(command: clap::Command, locale: UiLocale) -> clap::Comma
         sub.about(match locale {
             UiLocale::Ja => "管理対象ファイルと状態を表示する",
             UiLocale::En => "Show managed files and their status",
+        })
+        .mut_arg("git", |arg| {
+            arg.help(match locale {
+                UiLocale::Ja => "`git status --short --branch` も先に表示する",
+                UiLocale::En => "Also show `git status --short --branch` first",
+            })
         })
     });
     let command = command.mut_subcommand("diff", |sub| {

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -10,39 +10,107 @@ use crate::git::GitRepo;
 use crate::ui;
 use crate::{fs_util, path};
 
-pub fn run(file: &str, phantom: bool, no_exclude: bool, force: bool) -> Result<()> {
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum AddMode {
+    Auto,
+    Overlay,
+    Phantom,
+}
+
+pub fn run(
+    files: &[String],
+    overlay: bool,
+    phantom: bool,
+    no_exclude: bool,
+    force: bool,
+) -> Result<()> {
     let cwd = std::env::current_dir()?;
     let git = GitRepo::discover(&cwd)?;
-    run_with_repo(&git, &cwd, file, phantom, no_exclude, force)
+
+    let mode = if overlay {
+        AddMode::Overlay
+    } else if phantom {
+        AddMode::Phantom
+    } else {
+        AddMode::Auto
+    };
+
+    run_with_repo(&git, &cwd, files, mode, no_exclude, force)
 }
 
 fn run_with_repo(
     git: &GitRepo,
     cwd: &Path,
-    file: &str,
-    phantom: bool,
+    files: &[String],
+    mode: AddMode,
     no_exclude: bool,
     force: bool,
 ) -> Result<()> {
     let locale = ui::detect_locale();
-    let normalized = path::normalize_path(file, cwd, &git.root)?;
     git.ensure_initialized()?;
 
-    // Warn if hooks not installed
     if !git.hooks_installed() {
         eprintln!("{}", ui::warning_hooks_not_installed(locale).yellow());
     }
 
     let mut config = ShadowConfig::load(&git.shadow_dir)?;
+    let mut failures = 0usize;
 
-    if phantom {
-        add_phantom(git, &mut config, &normalized, no_exclude)?;
-    } else {
-        add_overlay(git, &mut config, &normalized, force)?;
+    for file in files {
+        let normalized = path::normalize_path(file, cwd, &git.root)?;
+
+        let resolved_mode = match resolve_mode(git, &normalized, mode) {
+            Ok(resolved_mode) => resolved_mode,
+            Err(err) => {
+                failures += 1;
+                eprintln!(
+                    "{}",
+                    ui::add_failed(locale, &normalized, &ui::format_error(&err, locale)).red()
+                );
+                continue;
+            }
+        };
+
+        let result = match resolved_mode {
+            AddMode::Overlay => add_overlay(git, &mut config, &normalized, force),
+            AddMode::Phantom => add_phantom(git, &mut config, &normalized, no_exclude),
+            AddMode::Auto => unreachable!("auto mode should be resolved before registration"),
+        };
+
+        if let Err(err) = result {
+            failures += 1;
+            eprintln!(
+                "{}",
+                ui::add_failed(locale, &normalized, &ui::format_error(&err, locale)).red()
+            );
+        }
     }
 
     config.save(&git.shadow_dir)?;
+
+    if failures > 0 {
+        return Err(ShadowError::AddSomeFailed(failures).into());
+    }
+
     Ok(())
+}
+
+fn resolve_mode(git: &GitRepo, normalized: &str, mode: AddMode) -> Result<AddMode> {
+    match mode {
+        AddMode::Overlay => Ok(AddMode::Overlay),
+        AddMode::Phantom => Ok(AddMode::Phantom),
+        AddMode::Auto => {
+            if git.is_tracked(normalized)? {
+                return Ok(AddMode::Overlay);
+            }
+
+            if git.root.join(normalized).exists() {
+                return Ok(AddMode::Phantom);
+            }
+
+            Err(ShadowError::PathDoesNotExist(normalized.to_string()).into())
+        }
+    }
 }
 
 fn add_overlay(
@@ -52,31 +120,26 @@ fn add_overlay(
     force: bool,
 ) -> Result<()> {
     let locale = ui::detect_locale();
-    // Check file is tracked
+
     if !git.is_tracked(normalized)? {
         return Err(ShadowError::FileNotTracked(normalized.to_string()).into());
     }
 
     let file_path = git.root.join(normalized);
 
-    // Binary check
     if fs_util::is_binary(&file_path)? {
         return Err(ShadowError::BinaryFile(normalized.to_string()).into());
     }
 
-    // Size check
     fs_util::check_size(&file_path, force)?;
 
-    // Get HEAD content as baseline
     let commit = git.head_commit()?;
     let baseline_content = git.show_file("HEAD", normalized)?;
 
-    // Save baseline
     let encoded = path::encode_path(normalized);
     let baseline_path = git.shadow_dir.join("baselines").join(&encoded);
     fs_util::atomic_write(&baseline_path, &baseline_content).context("failed to save baseline")?;
 
-    // Add to config
     config.add_overlay(normalized.to_string(), commit)?;
 
     println!(
@@ -101,12 +164,8 @@ fn add_phantom(
     normalized: &str,
     no_exclude: bool,
 ) -> Result<()> {
-    // Phantom files should NOT be tracked
     if git.is_tracked(normalized)? {
-        return Err(anyhow::anyhow!(
-            "file '{}' is already tracked by Git. Remove --phantom to register as overlay",
-            normalized
-        ));
+        return Err(ShadowError::TrackedFileNeedsOverlay(normalized.to_string()).into());
     }
 
     let full_path = git.root.join(normalized);
@@ -115,7 +174,6 @@ fn add_phantom(
     let exclude_mode = if no_exclude {
         ExcludeMode::None
     } else {
-        // Add to .git/info/exclude (with trailing / for directories)
         let exclude_path = if is_dir {
             format!("{}/", normalized)
         } else {
@@ -147,6 +205,7 @@ fn add_phantom(
 #[cfg(test)]
 mod tests {
     use super::*;
+
     fn make_test_repo() -> (tempfile::TempDir, GitRepo) {
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path().to_path_buf();
@@ -166,7 +225,6 @@ mod tests {
             .output()
             .unwrap();
 
-        // Create and commit a file
         std::fs::write(root.join("CLAUDE.md"), "# Team CLAUDE\n").unwrap();
         std::process::Command::new("git")
             .args(["add", "CLAUDE.md"])
@@ -180,12 +238,32 @@ mod tests {
             .unwrap();
 
         let repo = GitRepo::discover(&root).unwrap();
-
-        // Initialize shadow directory
         std::fs::create_dir_all(repo.shadow_dir.join("baselines")).unwrap();
         std::fs::create_dir_all(repo.shadow_dir.join("stash")).unwrap();
 
         (dir, repo)
+    }
+
+    #[test]
+    fn test_resolve_mode_auto_overlay_for_tracked() {
+        let (_dir, git) = make_test_repo();
+        let mode = resolve_mode(&git, "CLAUDE.md", AddMode::Auto).unwrap();
+        assert_eq!(mode, AddMode::Overlay);
+    }
+
+    #[test]
+    fn test_resolve_mode_auto_phantom_for_existing_untracked() {
+        let (_dir, git) = make_test_repo();
+        std::fs::write(git.root.join("local.md"), "# Local\n").unwrap();
+        let mode = resolve_mode(&git, "local.md", AddMode::Auto).unwrap();
+        assert_eq!(mode, AddMode::Phantom);
+    }
+
+    #[test]
+    fn test_resolve_mode_auto_rejects_missing_path() {
+        let (_dir, git) = make_test_repo();
+        let err = resolve_mode(&git, "missing.md", AddMode::Auto).unwrap_err();
+        assert!(err.to_string().contains("does not exist"));
     }
 
     #[test]
@@ -223,7 +301,6 @@ mod tests {
     #[test]
     fn test_add_overlay_rejects_binary() {
         let (_dir, git) = make_test_repo();
-        // Create and commit a binary file
         let mut content = b"hello".to_vec();
         content.push(0x00);
         std::fs::write(git.root.join("bin.dat"), &content).unwrap();
@@ -255,7 +332,6 @@ mod tests {
     #[test]
     fn test_add_phantom_creates_config_entry() {
         let (_dir, git) = make_test_repo();
-        // Create a phantom file (not tracked)
         let phantom_dir = git.root.join("src").join("components");
         std::fs::create_dir_all(&phantom_dir).unwrap();
         std::fs::write(phantom_dir.join("CLAUDE.md"), "# Local\n").unwrap();
@@ -273,7 +349,6 @@ mod tests {
         let (_dir, git) = make_test_repo();
         std::fs::create_dir_all(git.root.join("src")).unwrap();
         std::fs::write(git.root.join("src/CLAUDE.md"), "# Local\n").unwrap();
-        // Ensure info dir exists
         std::fs::create_dir_all(git.common_dir.join("info")).unwrap();
 
         let mut config = ShadowConfig::new();
@@ -300,7 +375,6 @@ mod tests {
     #[test]
     fn test_add_phantom_directory_creates_config_entry() {
         let (_dir, git) = make_test_repo();
-        // Create an untracked directory
         std::fs::create_dir_all(git.root.join(".claude")).unwrap();
         std::fs::write(git.root.join(".claude/settings.json"), "{}").unwrap();
 
@@ -324,11 +398,7 @@ mod tests {
 
         let manager = ExcludeManager::new(&git.common_dir);
         let entries = manager.list_entries().unwrap();
-        assert!(
-            entries.contains(&".claude/".to_string()),
-            "exclude entry should have trailing slash for directory, got: {:?}",
-            entries
-        );
+        assert!(entries.contains(&".claude/".to_string()));
     }
 
     #[test]
@@ -370,7 +440,9 @@ mod tests {
         let (_dir, git) = make_test_repo();
         std::fs::remove_dir_all(&git.shadow_dir).unwrap();
 
-        let err = run_with_repo(&git, &git.root, "CLAUDE.md", false, false, false).unwrap_err();
+        let files = vec!["CLAUDE.md".to_string()];
+        let err =
+            run_with_repo(&git, &git.root, &files, AddMode::Overlay, false, false).unwrap_err();
         assert!(err.to_string().contains("Run `git-shadow install`"));
     }
 
@@ -380,7 +452,9 @@ mod tests {
         std::fs::remove_dir_all(&git.shadow_dir).unwrap();
         std::fs::write(git.root.join("local.md"), "# Local\n").unwrap();
 
-        let err = run_with_repo(&git, &git.root, "local.md", true, false, false).unwrap_err();
+        let files = vec!["local.md".to_string()];
+        let err =
+            run_with_repo(&git, &git.root, &files, AddMode::Phantom, false, false).unwrap_err();
         assert!(err.to_string().contains("Run `git-shadow install`"));
     }
 
@@ -394,8 +468,41 @@ mod tests {
         let cwd = git.root.join("src");
         std::fs::create_dir_all(&cwd).unwrap();
 
-        let err =
-            run_with_repo(&git, &cwd, "../../outside/local.md", true, false, false).unwrap_err();
+        let files = vec!["../../outside/local.md".to_string()];
+        let err = run_with_repo(&git, &cwd, &files, AddMode::Phantom, false, false).unwrap_err();
         assert!(err.to_string().contains("outside repository"));
+    }
+
+    #[test]
+    fn test_run_auto_detects_mixed_inputs() {
+        let (_dir, git) = make_test_repo();
+        std::fs::write(git.root.join("local.md"), "# Local\n").unwrap();
+
+        let files = vec!["CLAUDE.md".to_string(), "local.md".to_string()];
+        run_with_repo(&git, &git.root, &files, AddMode::Auto, false, false).unwrap();
+
+        let config = ShadowConfig::load(&git.shadow_dir).unwrap();
+        assert_eq!(
+            config.get("CLAUDE.md").unwrap().file_type,
+            crate::config::FileType::Overlay
+        );
+        assert_eq!(
+            config.get("local.md").unwrap().file_type,
+            crate::config::FileType::Phantom
+        );
+    }
+
+    #[test]
+    fn test_run_returns_error_when_any_input_fails() {
+        let (_dir, git) = make_test_repo();
+        std::fs::write(git.root.join("local.md"), "# Local\n").unwrap();
+
+        let files = vec!["local.md".to_string(), "missing.md".to_string()];
+        let err = run_with_repo(&git, &git.root, &files, AddMode::Auto, false, false).unwrap_err();
+        assert!(!err.to_string().is_empty());
+
+        let config = ShadowConfig::load(&git.shadow_dir).unwrap();
+        assert!(config.get("local.md").is_some());
+        assert!(config.get("missing.md").is_none());
     }
 }

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -7,7 +7,7 @@ use crate::lock::{self, LockStatus};
 use crate::path;
 use crate::ui;
 
-const HOOK_NAMES: &[&str] = &["pre-commit", "post-commit", "post-merge"];
+const HOOK_NAMES: &[&str] = &["pre-commit", "post-commit", "post-merge", "post-rewrite"];
 const COMPETING_HOOKS: &[&str] = &[".husky", ".pre-commit-config.yaml", "lefthook.yml"];
 
 pub fn run() -> Result<()> {

--- a/src/commands/hook.rs
+++ b/src/commands/hook.rs
@@ -10,6 +10,7 @@ pub fn run(hook_name: &str) -> Result<()> {
         "pre-commit" => hooks::pre_commit::handle(&git),
         "post-commit" => hooks::post_commit::handle(&git),
         "post-merge" => hooks::post_merge::handle(&git),
+        "post-rewrite" => hooks::post_rewrite::handle(&git),
         _ => bail!("unknown hook name: {}", hook_name),
     }
 }

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -7,7 +7,7 @@ use crate::git::GitRepo;
 use crate::ui;
 use crate::{fs_util, path};
 
-const HOOK_NAMES: &[&str] = &["pre-commit", "post-commit", "post-merge"];
+const HOOK_NAMES: &[&str] = &["pre-commit", "post-commit", "post-merge", "post-rewrite"];
 
 fn generate_hook_script(hook_name: &str) -> String {
     format!(

--- a/src/commands/rebase.rs
+++ b/src/commands/rebase.rs
@@ -9,6 +9,19 @@ use crate::merge;
 use crate::path;
 use crate::ui;
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RebaseMode {
+    Manual,
+    Auto,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RebaseOutcome {
+    Updated,
+    CommitRefUpdated,
+    ConflictDeferred,
+}
+
 pub fn run(file: Option<&str>) -> Result<()> {
     let locale = ui::detect_locale();
     let cwd = std::env::current_dir()?;
@@ -66,6 +79,16 @@ pub(crate) fn rebase_file(
     file_path: &str,
     new_head: &str,
 ) -> Result<()> {
+    rebase_file_with_mode(git, config, file_path, new_head, RebaseMode::Manual).map(|_| ())
+}
+
+pub(crate) fn rebase_file_with_mode(
+    git: &GitRepo,
+    config: &mut ShadowConfig,
+    file_path: &str,
+    new_head: &str,
+    mode: RebaseMode,
+) -> Result<RebaseOutcome> {
     let encoded = path::encode_path(file_path);
     let baseline_path = git.shadow_dir.join("baselines").join(&encoded);
     let worktree_path = git.root.join(file_path);
@@ -93,11 +116,17 @@ pub(crate) fn rebase_file(
         if let Some(entry) = config.files.get_mut(file_path) {
             entry.baseline_commit = Some(new_head.to_string());
         }
-        println!(
-            "{}",
-            ui::rebase_commit_ref_updated(ui::detect_locale(), file_path)
-        );
-        return Ok(());
+        match mode {
+            RebaseMode::Manual => println!(
+                "{}",
+                ui::rebase_commit_ref_updated(ui::detect_locale(), file_path)
+            ),
+            RebaseMode::Auto => eprintln!(
+                "{}",
+                ui::auto_rebase_commit_ref_updated(ui::detect_locale(), file_path)
+            ),
+        }
+        return Ok(RebaseOutcome::CommitRefUpdated);
     }
 
     // 4. 3-way merge: old_baseline (base), current_content (ours), new_baseline (theirs)
@@ -107,6 +136,14 @@ pub(crate) fn rebase_file(
         &new_baseline,
         &git.shadow_dir,
     )?;
+
+    if mode == RebaseMode::Auto && merge_result.has_conflicts {
+        eprintln!(
+            "{}",
+            ui::auto_rebase_conflict_warning(ui::detect_locale(), file_path).yellow()
+        );
+        return Ok(RebaseOutcome::ConflictDeferred);
+    }
 
     // 5. Write merged content to working tree
     std::fs::write(&worktree_path, &merge_result.content)?;
@@ -125,12 +162,53 @@ pub(crate) fn rebase_file(
             ui::rebase_conflicts(ui::detect_locale(), file_path).yellow()
         );
     } else {
-        println!(
-            "{}",
-            ui::rebase_updated(ui::detect_locale(), file_path).green()
-        );
+        match mode {
+            RebaseMode::Manual => println!(
+                "{}",
+                ui::rebase_updated(ui::detect_locale(), file_path).green()
+            ),
+            RebaseMode::Auto => eprintln!(
+                "{}",
+                ui::auto_rebase_updated(ui::detect_locale(), file_path).yellow()
+            ),
+        }
     }
 
+    Ok(RebaseOutcome::Updated)
+}
+
+pub fn auto_rebase_all(git: &GitRepo, trigger: &str) -> Result<()> {
+    let mut config = ShadowConfig::load(&git.shadow_dir)?;
+    if config.suspended || config.files.is_empty() {
+        return Ok(());
+    }
+
+    let head = git.head_commit()?;
+    let file_paths: Vec<String> = config.files.keys().cloned().collect();
+
+    for file_path in file_paths {
+        let Some(entry) = config.files.get(&file_path) else {
+            continue;
+        };
+        if entry.file_type != FileType::Overlay {
+            continue;
+        }
+
+        if entry.baseline_commit.as_deref() == Some(head.as_str()) {
+            continue;
+        }
+
+        match rebase_file_with_mode(git, &mut config, &file_path, &head, RebaseMode::Auto) {
+            Ok(_) => {}
+            Err(err) => eprintln!(
+                "{}",
+                ui::auto_rebase_failed(ui::detect_locale(), &file_path, trigger, &err.to_string())
+                    .yellow()
+            ),
+        }
+    }
+
+    config.save(&git.shadow_dir)?;
     Ok(())
 }
 

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -7,12 +7,24 @@ use crate::lock::{self, LockStatus};
 use crate::path;
 use crate::ui;
 
-pub fn run() -> Result<()> {
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum OverlayGitState {
+    Clean,
+    Modified,
+    Staged,
+    PartiallyStaged,
+}
+
+pub fn run(show_git_status: bool) -> Result<()> {
     let locale = ui::detect_locale();
     let git = GitRepo::discover(&std::env::current_dir()?)?;
     let config = ShadowConfig::load(&git.shadow_dir)?;
 
-    // Check for stash remnants
+    if show_git_status {
+        print!("{}", git.status_short()?);
+        println!();
+    }
+
     let stash_dir = git.shadow_dir.join("stash");
     if stash_dir.exists() {
         let stash_files: Vec<_> = std::fs::read_dir(&stash_dir)?
@@ -26,7 +38,6 @@ pub fn run() -> Result<()> {
         }
     }
 
-    // Check for stale lock
     if let LockStatus::Stale(info) = lock::check_lock(&git.shadow_dir)? {
         println!(
             "{}",
@@ -53,6 +64,7 @@ pub fn run() -> Result<()> {
         match entry.file_type {
             FileType::Overlay => {
                 println!("  {} ({})", file_path, ui::label_overlay(locale));
+                println!("{}", ui::status_overlay_local_only(locale));
                 if let Some(ref commit) = entry.baseline_commit {
                     println!(
                         "{}",
@@ -60,7 +72,6 @@ pub fn run() -> Result<()> {
                     );
                 }
 
-                // Show diff stats
                 let encoded = path::encode_path(file_path);
                 let baseline_path = git.shadow_dir.join("baselines").join(&encoded);
                 let worktree_path = git.root.join(file_path);
@@ -76,11 +87,21 @@ pub fn run() -> Result<()> {
                     let (added, removed) = diff_stats(&baseline, &current);
                     println!("{}", ui::status_shadow_changes(locale, added, removed));
 
-                    // Check baseline drift (hash mismatch + content comparison)
+                    let git_state = overlay_git_state(git.staging_status(file_path)?);
+                    println!(
+                        "{}",
+                        ui::status_overlay_git_state(locale, git_state_label(git_state))
+                    );
+                    if matches!(
+                        git_state,
+                        OverlayGitState::Staged | OverlayGitState::PartiallyStaged
+                    ) {
+                        println!("{}", ui::status_overlay_staged_warning(locale).yellow());
+                    }
+
                     if let Some(ref commit) = entry.baseline_commit {
                         if let Ok(head) = git.head_commit() {
                             if *commit != head {
-                                // Hash differs — check if file content actually changed
                                 let content_changed = git
                                     .show_file("HEAD", file_path)
                                     .ok()
@@ -119,6 +140,9 @@ pub fn run() -> Result<()> {
                     ui::label_phantom(locale)
                 };
                 println!("  {} ({})", file_path, label);
+                if entry.is_directory {
+                    println!("{}", ui::status_phantom_dir_explainer(locale));
+                }
                 match entry.exclude_mode {
                     crate::config::ExcludeMode::GitInfoExclude => {
                         println!("{}", ui::status_exclude_git_info(locale));
@@ -151,7 +175,29 @@ pub fn run() -> Result<()> {
         }
     }
 
+    if show_git_status {
+        println!("{}", ui::status_git_wrapper_hint(locale));
+    }
+
     Ok(())
+}
+
+fn overlay_git_state(status: (bool, bool)) -> OverlayGitState {
+    match status {
+        (true, true) => OverlayGitState::PartiallyStaged,
+        (true, false) => OverlayGitState::Staged,
+        (false, true) => OverlayGitState::Modified,
+        (false, false) => OverlayGitState::Clean,
+    }
+}
+
+fn git_state_label(state: OverlayGitState) -> &'static str {
+    match state {
+        OverlayGitState::Clean => "clean",
+        OverlayGitState::Modified => "modified",
+        OverlayGitState::Staged => "staged",
+        OverlayGitState::PartiallyStaged => "partially staged",
+    }
 }
 
 fn diff_stats(old: &str, new: &str) -> (usize, usize) {
@@ -183,6 +229,29 @@ fn format_size(bytes: u64) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_overlay_git_state_clean() {
+        assert_eq!(overlay_git_state((false, false)), OverlayGitState::Clean);
+    }
+
+    #[test]
+    fn test_overlay_git_state_modified() {
+        assert_eq!(overlay_git_state((false, true)), OverlayGitState::Modified);
+    }
+
+    #[test]
+    fn test_overlay_git_state_staged() {
+        assert_eq!(overlay_git_state((true, false)), OverlayGitState::Staged);
+    }
+
+    #[test]
+    fn test_overlay_git_state_partially_staged() {
+        assert_eq!(
+            overlay_git_state((true, true)),
+            OverlayGitState::PartiallyStaged
+        );
+    }
 
     #[test]
     fn test_diff_stats_no_change() {

--- a/src/error.rs
+++ b/src/error.rs
@@ -11,6 +11,12 @@ pub enum ShadowError {
     #[error("file '{0}' is not tracked by Git")]
     FileNotTracked(String),
 
+    #[error("path '{0}' does not exist")]
+    PathDoesNotExist(String),
+
+    #[error("file '{0}' is already tracked by Git. Remove --phantom to register it as overlay")]
+    TrackedFileNeedsOverlay(String),
+
     #[error("file '{0}' is already managed by git-shadow")]
     AlreadyManaged(String),
 
@@ -29,6 +35,9 @@ pub enum ShadowError {
     #[error("stale lock detected (PID {0} no longer exists). Run `git-shadow restore`")]
     StaleLock(u32),
 
+    #[error("automatic stale-lock recovery would overwrite newer working tree content in '{0}'. Run `git-shadow restore` manually")]
+    AutoRestoreConflict(String),
+
     #[error("stash has remaining files. Run `git-shadow restore`")]
     StashRemaining,
 
@@ -43,6 +52,9 @@ pub enum ShadowError {
 
     #[error("failed to unstage phantom file '{0}'. Run `git reset -- {0}` manually")]
     UnstageFailure(String),
+
+    #[error("failed to register {0} path(s); see errors above")]
+    AddSomeFailed(usize),
 
     #[error("git command failed: {command}\n{stderr}")]
     GitCommand { command: String, stderr: String },

--- a/src/git.rs
+++ b/src/git.rs
@@ -195,6 +195,24 @@ impl GitRepo {
         Ok((false, false))
     }
 
+    /// Return `git status --short --branch` output.
+    pub fn status_short(&self) -> anyhow::Result<String> {
+        let output = Command::new("git")
+            .args(["status", "--short", "--branch"])
+            .current_dir(&self.root)
+            .output()
+            .context("failed to run git status")?;
+
+        if !output.status.success() {
+            bail!(
+                "git status --short --branch failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+
+        Ok(String::from_utf8_lossy(&output.stdout).to_string())
+    }
+
     /// Stage a file (git add)
     pub fn add(&self, path: &str) -> anyhow::Result<()> {
         self.run_git(&["add", path])?;
@@ -227,7 +245,7 @@ impl GitRepo {
     /// Check if hooks are installed
     pub fn hooks_installed(&self) -> bool {
         let hooks_dir = self.hooks_dir();
-        ["pre-commit", "post-commit", "post-merge"]
+        ["pre-commit", "post-commit", "post-merge", "post-rewrite"]
             .iter()
             .all(|name| {
                 let hook = hooks_dir.join(name);

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -1,3 +1,4 @@
 pub mod post_commit;
 pub mod post_merge;
+pub mod post_rewrite;
 pub mod pre_commit;

--- a/src/hooks/post_merge.rs
+++ b/src/hooks/post_merge.rs
@@ -1,42 +1,10 @@
 use anyhow::Result;
-use colored::Colorize;
 
-use crate::config::{FileType, ShadowConfig};
+use crate::commands::rebase;
 use crate::git::GitRepo;
-use crate::path;
-use crate::ui;
 
 pub fn handle(git: &GitRepo) -> Result<()> {
-    let config = ShadowConfig::load(&git.shadow_dir)?;
-    let head = git.head_commit()?;
-
-    for (file_path, entry) in &config.files {
-        if entry.file_type != FileType::Overlay {
-            continue;
-        }
-
-        if let Some(ref baseline_commit) = entry.baseline_commit {
-            if *baseline_commit == head {
-                continue;
-            }
-
-            // Check if file content actually changed
-            let encoded = path::encode_path(file_path);
-            let baseline_path = git.shadow_dir.join("baselines").join(&encoded);
-            if let Ok(baseline_content) = std::fs::read(&baseline_path) {
-                if let Ok(head_content) = git.show_file("HEAD", file_path) {
-                    if baseline_content != head_content {
-                        eprintln!(
-                            "{}",
-                            ui::baseline_outdated_warning(ui::detect_locale(), file_path).yellow()
-                        );
-                    }
-                }
-            }
-        }
-    }
-
-    Ok(())
+    rebase::auto_rebase_all(git, "post-merge")
 }
 
 #[cfg(test)]
@@ -44,6 +12,7 @@ mod tests {
     use super::*;
     use crate::config::ShadowConfig;
     use crate::fs_util;
+    use crate::path;
 
     fn make_test_repo() -> (tempfile::TempDir, GitRepo) {
         let dir = tempfile::tempdir().unwrap();
@@ -82,59 +51,54 @@ mod tests {
     }
 
     #[test]
-    fn test_no_warning_when_baseline_matches() {
+    fn test_post_merge_auto_rebases_clean_changes() {
         let (_dir, git) = make_test_repo();
-        let commit = git.head_commit().unwrap();
-        let mut config = ShadowConfig::new();
-        config.add_overlay("CLAUDE.md".to_string(), commit).unwrap();
-
-        // Save baseline
-        let content = git.show_file("HEAD", "CLAUDE.md").unwrap();
-        fs_util::atomic_write(
-            &git.shadow_dir.join("baselines").join("CLAUDE.md"),
-            &content,
-        )
-        .unwrap();
-
-        config.save(&git.shadow_dir).unwrap();
-
-        // Should not error
-        handle(&git).unwrap();
-    }
-
-    #[test]
-    fn test_detects_baseline_drift() {
-        let (_dir, git) = make_test_repo();
-        let old_commit = git.head_commit().unwrap();
-        let mut config = ShadowConfig::new();
-        config
-            .add_overlay("CLAUDE.md".to_string(), old_commit)
-            .unwrap();
-
-        // Save old baseline
-        let content = git.show_file("HEAD", "CLAUDE.md").unwrap();
-        fs_util::atomic_write(
-            &git.shadow_dir.join("baselines").join("CLAUDE.md"),
-            &content,
-        )
-        .unwrap();
-
-        config.save(&git.shadow_dir).unwrap();
-
-        // Make a new commit that changes the file
-        std::fs::write(git.root.join("CLAUDE.md"), "# Updated Team\n").unwrap();
+        std::fs::write(git.root.join("CLAUDE.md"), "line1\nline2\nline3\n").unwrap();
         std::process::Command::new("git")
             .args(["add", "CLAUDE.md"])
             .current_dir(&git.root)
             .output()
             .unwrap();
         std::process::Command::new("git")
-            .args(["commit", "-m", "update"])
+            .args(["commit", "-m", "set base"])
             .current_dir(&git.root)
             .output()
             .unwrap();
 
-        // Should not error (warnings go to stderr)
+        let old_commit = git.head_commit().unwrap();
+        let mut config = ShadowConfig::new();
+        config
+            .add_overlay("CLAUDE.md".to_string(), old_commit)
+            .unwrap();
+        let encoded = path::encode_path("CLAUDE.md");
+        fs_util::atomic_write(
+            &git.shadow_dir.join("baselines").join(&encoded),
+            b"line1\nline2\nline3\n",
+        )
+        .unwrap();
+        config.save(&git.shadow_dir).unwrap();
+
+        std::fs::write(git.root.join("CLAUDE.md"), "line1\nline2 modified\nline3\n").unwrap();
+        std::fs::write(git.root.join("CLAUDE.md"), "line1\nline2\nline3\nline4\n").unwrap();
+        std::process::Command::new("git")
+            .args(["add", "CLAUDE.md"])
+            .current_dir(&git.root)
+            .output()
+            .unwrap();
+        std::process::Command::new("git")
+            .args(["commit", "-m", "upstream"])
+            .current_dir(&git.root)
+            .output()
+            .unwrap();
+        std::fs::write(git.root.join("CLAUDE.md"), "line1\nline2 modified\nline3\n").unwrap();
+
         handle(&git).unwrap();
+
+        let baseline =
+            std::fs::read_to_string(git.shadow_dir.join("baselines").join(&encoded)).unwrap();
+        assert_eq!(baseline, "line1\nline2\nline3\nline4\n");
+        let wt = std::fs::read_to_string(git.root.join("CLAUDE.md")).unwrap();
+        assert!(wt.contains("line2 modified"));
+        assert!(wt.contains("line4"));
     }
 }

--- a/src/hooks/post_rewrite.rs
+++ b/src/hooks/post_rewrite.rs
@@ -1,0 +1,8 @@
+use anyhow::Result;
+
+use crate::commands::rebase;
+use crate::git::GitRepo;
+
+pub fn handle(git: &GitRepo) -> Result<()> {
+    rebase::auto_rebase_all(git, "post-rewrite")
+}

--- a/src/hooks/pre_commit.rs
+++ b/src/hooks/pre_commit.rs
@@ -51,7 +51,7 @@ impl PreCommitTransaction {
 }
 
 pub fn handle(git: &GitRepo) -> Result<()> {
-    // 0. Acquire lock
+    maybe_recover_stale_state(git)?;
     lock::acquire_lock(&git.shadow_dir)?;
 
     let config = ShadowConfig::load(&git.shadow_dir)?;
@@ -130,6 +130,16 @@ fn run_soft_checks(git: &GitRepo, config: &ShadowConfig) {
 
     for (file_path, entry) in &config.files {
         if entry.file_type == FileType::Overlay {
+            if let Ok((index_changed, worktree_changed)) = git.staging_status(file_path) {
+                if index_changed && !worktree_changed {
+                    eprintln!(
+                        "{}",
+                        ui::pre_commit_overlay_staged_warning(ui::detect_locale(), file_path)
+                            .yellow()
+                    );
+                }
+            }
+
             if let (Some(ref baseline_commit), Some(ref current_head)) =
                 (&entry.baseline_commit, &head)
             {
@@ -156,6 +166,96 @@ fn run_soft_checks(git: &GitRepo, config: &ShadowConfig) {
             }
         }
     }
+}
+
+fn maybe_recover_stale_state(git: &GitRepo) -> Result<()> {
+    let stale_pid = match lock::check_lock(&git.shadow_dir)? {
+        lock::LockStatus::Stale(info) => Some(info.pid),
+        _ => None,
+    };
+
+    let Some(pid) = stale_pid else {
+        return Ok(());
+    };
+
+    let stash_entries = list_stash_entries(git)?;
+    if stash_entries.is_empty() {
+        lock::release_lock(&git.shadow_dir)?;
+        eprintln!(
+            "{}",
+            ui::stale_lock_recovered(ui::detect_locale(), pid).yellow()
+        );
+        return Ok(());
+    }
+
+    let config = ShadowConfig::load(&git.shadow_dir)?;
+    for (normalized, stash_path) in &stash_entries {
+        let entry = config
+            .get(normalized)
+            .ok_or_else(|| ShadowError::AutoRestoreConflict(normalized.clone()))?;
+        let stash_content = std::fs::read(stash_path)?;
+        let worktree_path = git.root.join(normalized);
+
+        match entry.file_type {
+            FileType::Overlay => {
+                let baseline_path = git
+                    .shadow_dir
+                    .join("baselines")
+                    .join(path::encode_path(normalized));
+                let baseline = std::fs::read(&baseline_path)
+                    .map_err(|_| ShadowError::BaselineMissing(normalized.clone()))?;
+                let current = std::fs::read(&worktree_path)
+                    .map_err(|_| ShadowError::FileMissing(normalized.clone()))?;
+                if current != baseline && current != stash_content {
+                    return Err(ShadowError::AutoRestoreConflict(normalized.clone()).into());
+                }
+            }
+            FileType::Phantom => {
+                if worktree_path.exists() {
+                    let current = std::fs::read(&worktree_path)?;
+                    if current != stash_content {
+                        return Err(ShadowError::AutoRestoreConflict(normalized.clone()).into());
+                    }
+                }
+            }
+        }
+    }
+
+    for (normalized, stash_path) in stash_entries {
+        let worktree_path = git.root.join(&normalized);
+        if let Some(parent) = worktree_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let content = std::fs::read(&stash_path)?;
+        std::fs::write(&worktree_path, &content)?;
+        std::fs::remove_file(&stash_path)?;
+    }
+
+    lock::release_lock(&git.shadow_dir)?;
+    eprintln!(
+        "{}",
+        ui::stale_lock_recovered(ui::detect_locale(), pid).yellow()
+    );
+    Ok(())
+}
+
+fn list_stash_entries(git: &GitRepo) -> Result<Vec<(String, std::path::PathBuf)>> {
+    let stash_dir = git.shadow_dir.join("stash");
+    if !stash_dir.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut entries = Vec::new();
+    for entry in std::fs::read_dir(&stash_dir)? {
+        let entry = entry?;
+        if !entry.file_type()?.is_file() {
+            continue;
+        }
+        let encoded = entry.file_name().to_string_lossy().to_string();
+        entries.push((path::decode_path(&encoded), entry.path()));
+    }
+
+    Ok(entries)
 }
 
 fn detect_partial_staging(git: &GitRepo, config: &ShadowConfig) -> Result<()> {
@@ -490,5 +590,73 @@ mod tests {
         // Lock should be released
         let status = lock::check_lock(&git.shadow_dir).unwrap();
         assert!(matches!(status, LockStatus::Free));
+    }
+
+    #[test]
+    fn test_stale_lock_without_stash_is_removed_automatically() {
+        let (_dir, git) = make_test_repo();
+        let config = ShadowConfig::new();
+        config.save(&git.shadow_dir).unwrap();
+
+        std::fs::write(
+            git.shadow_dir.join("lock"),
+            "pid=999999\ntimestamp=2026-01-01T00:00:00+00:00",
+        )
+        .unwrap();
+
+        handle(&git).unwrap();
+
+        let status = lock::check_lock(&git.shadow_dir).unwrap();
+        assert!(matches!(status, LockStatus::Free));
+    }
+
+    #[test]
+    fn test_stale_lock_with_safe_overlay_stash_is_restored_automatically() {
+        let (_dir, git) = make_test_repo();
+        let _config = setup_overlay(&git);
+
+        let baseline = std::fs::read_to_string(git.root.join("CLAUDE.md")).unwrap();
+        fs_util::atomic_write(
+            &git.shadow_dir.join("stash").join("CLAUDE.md"),
+            b"# Team\n# My additions\n",
+        )
+        .unwrap();
+        std::fs::write(git.root.join("CLAUDE.md"), baseline).unwrap();
+        std::fs::write(
+            git.shadow_dir.join("lock"),
+            "pid=999999\ntimestamp=2026-01-01T00:00:00+00:00",
+        )
+        .unwrap();
+
+        handle(&git).unwrap();
+
+        let stash =
+            std::fs::read_to_string(git.shadow_dir.join("stash").join("CLAUDE.md")).unwrap();
+        assert_eq!(stash, "# Team\n# My additions\n");
+        let wt = std::fs::read_to_string(git.root.join("CLAUDE.md")).unwrap();
+        assert_eq!(wt, "# Team\n");
+
+        lock::release_lock(&git.shadow_dir).unwrap();
+    }
+
+    #[test]
+    fn test_stale_lock_conflict_blocks_automatic_restore() {
+        let (_dir, git) = make_test_repo();
+        let _config = setup_overlay(&git);
+
+        fs_util::atomic_write(
+            &git.shadow_dir.join("stash").join("CLAUDE.md"),
+            b"# Team\n# My additions\n",
+        )
+        .unwrap();
+        std::fs::write(git.root.join("CLAUDE.md"), "# Team\n# Newer edit\n").unwrap();
+        std::fs::write(
+            git.shadow_dir.join("lock"),
+            "pid=999999\ntimestamp=2026-01-01T00:00:00+00:00",
+        )
+        .unwrap();
+
+        let err = handle(&git).unwrap_err();
+        assert!(err.to_string().contains("overwrite"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,13 +16,14 @@ fn run() -> anyhow::Result<()> {
     match cli.command {
         Commands::Install => commands::install::run()?,
         Commands::Add {
-            file,
+            files,
+            overlay,
             phantom,
             no_exclude,
             force,
-        } => commands::add::run(&file, phantom, no_exclude, force)?,
+        } => commands::add::run(&files, overlay, phantom, no_exclude, force)?,
         Commands::Remove { file, force } => commands::remove::run(&file, force)?,
-        Commands::Status => commands::status::run()?,
+        Commands::Status { git } => commands::status::run(git)?,
         Commands::Diff { file } => commands::diff::run(file.as_deref())?,
         Commands::Rebase { file } => commands::rebase::run(file.as_deref())?,
         Commands::Restore { file } => commands::restore::run(file.as_deref())?,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -54,6 +54,13 @@ pub fn registered_phantom_directory(locale: UiLocale, path: &str) -> String {
     }
 }
 
+pub fn add_failed(locale: UiLocale, path: &str, message: &str) -> String {
+    match locale {
+        UiLocale::Ja => format!("{path} の登録に失敗しました: {message}"),
+        UiLocale::En => format!("failed to register {path}: {message}"),
+    }
+}
+
 pub fn no_managed_files(locale: UiLocale) -> &'static str {
     choose(locale, "管理対象ファイルはありません", "no managed files")
 }
@@ -298,6 +305,66 @@ pub fn baseline_outdated_warning(locale: UiLocale, path: &str) -> String {
     }
 }
 
+pub fn stale_lock_recovered(locale: UiLocale, pid: u32) -> String {
+    match locale {
+        UiLocale::Ja => {
+            format!("warning: stale lock (PID {pid}) を安全に回復しました。commit を続行します")
+        }
+        UiLocale::En => {
+            format!("warning: recovered stale lock from PID {pid} safely; continuing commit")
+        }
+    }
+}
+
+pub fn pre_commit_overlay_staged_warning(locale: UiLocale, path: &str) -> String {
+    match locale {
+        UiLocale::Ja => format!(
+            "warning: `{path}` の local-only changes は現在 stage されていますが、commit 時に取り除かれます"
+        ),
+        UiLocale::En => format!(
+            "warning: local-only changes in `{path}` are staged right now, but will be stripped before commit"
+        ),
+    }
+}
+
+pub fn auto_rebase_commit_ref_updated(locale: UiLocale, path: &str) -> String {
+    match locale {
+        UiLocale::Ja => format!("{path}: baseline の commit ref を自動更新しました"),
+        UiLocale::En => format!("{path}: auto-updated baseline commit reference"),
+    }
+}
+
+pub fn auto_rebase_updated(locale: UiLocale, path: &str) -> String {
+    match locale {
+        UiLocale::Ja => format!("{path}: baseline を自動更新して shadow changes を再適用しました"),
+        UiLocale::En => {
+            format!("{path}: auto-updated baseline and re-applied shadow changes")
+        }
+    }
+}
+
+pub fn auto_rebase_conflict_warning(locale: UiLocale, path: &str) -> String {
+    match locale {
+        UiLocale::Ja => format!(
+            "warning: {path} は自動 rebase で conflict しそうなので作業ツリーは変更しません。`git-shadow rebase {path}` を実行してください"
+        ),
+        UiLocale::En => format!(
+            "warning: auto-rebase for {path} would conflict, so the working tree was left untouched. Run `git-shadow rebase {path}`"
+        ),
+    }
+}
+
+pub fn auto_rebase_failed(locale: UiLocale, path: &str, trigger: &str, error: &str) -> String {
+    match locale {
+        UiLocale::Ja => {
+            format!("warning: {trigger} で {path} の自動 rebase に失敗しました: {error}")
+        }
+        UiLocale::En => {
+            format!("warning: {trigger} auto-rebase failed for {path}: {error}")
+        }
+    }
+}
+
 pub fn post_commit_restore_failed(locale: UiLocale, path: &str, error: &str) -> String {
     match locale {
         UiLocale::Ja => format!("warning: {path} の復元に失敗しました: {error}"),
@@ -487,6 +554,14 @@ pub fn status_heading_managed_files(locale: UiLocale) -> &'static str {
     choose(locale, "managed files:", "managed files:")
 }
 
+pub fn status_overlay_local_only(locale: UiLocale) -> &'static str {
+    choose(
+        locale,
+        "    local-only: このファイルの変更は working tree には残りますが commit には入りません",
+        "    local-only: changes in this file stay in your working tree but are not committed",
+    )
+}
+
 pub fn label_overlay(locale: UiLocale) -> &'static str {
     choose(locale, "overlay", "overlay")
 }
@@ -504,6 +579,21 @@ pub fn status_baseline(locale: UiLocale, commit: &str) -> String {
         UiLocale::Ja => format!("    baseline: {commit}"),
         UiLocale::En => format!("    baseline: {commit}"),
     }
+}
+
+pub fn status_overlay_git_state(locale: UiLocale, state: &str) -> String {
+    match locale {
+        UiLocale::Ja => format!("    git state: {state}"),
+        UiLocale::En => format!("    git state: {state}"),
+    }
+}
+
+pub fn status_overlay_staged_warning(locale: UiLocale) -> &'static str {
+    choose(
+        locale,
+        "    warning: stage されている local-only changes は commit 前に取り除かれます",
+        "    warning: staged local-only changes will be stripped before commit",
+    )
 }
 
 pub fn status_warning_file_missing_worktree(locale: UiLocale) -> &'static str {
@@ -559,6 +649,14 @@ pub fn status_exclude_none(locale: UiLocale) -> &'static str {
     )
 }
 
+pub fn status_phantom_dir_explainer(locale: UiLocale) -> &'static str {
+    choose(
+        locale,
+        "    local-only directory: Git には含まれず、git-shadow が存在だけを保護します",
+        "    local-only directory: not committed to Git; git-shadow only protects its presence",
+    )
+}
+
 pub fn status_contents(locale: UiLocale, count: usize) -> String {
     match locale {
         UiLocale::Ja => format!("    contents: {count} entries"),
@@ -589,6 +687,14 @@ pub fn status_file_size(locale: UiLocale, size: &str) -> String {
     }
 }
 
+pub fn status_git_wrapper_hint(locale: UiLocale) -> &'static str {
+    choose(
+        locale,
+        "tip: 普段使いには `git shadow status --git` を shell alias にすると扱いやすいです",
+        "tip: for daily use, consider a shell alias for `git shadow status --git`",
+    )
+}
+
 fn choose(locale: UiLocale, ja: &'static str, en: &'static str) -> &'static str {
     match locale {
         UiLocale::Ja => ja,
@@ -611,9 +717,15 @@ fn format_shadow_error(err: &ShadowError, locale: UiLocale) -> String {
 fn format_shadow_error_ja(err: &ShadowError) -> String {
     match err {
         ShadowError::NotAGitRepo => "エラー: Git リポジトリではありません".to_string(),
+        ShadowError::PathDoesNotExist(path) => {
+            format!("エラー: `{path}` は存在しません")
+        }
         ShadowError::FileNotTracked(path) => {
             format!("エラー: `{path}` は Git に追跡されていません")
         }
+        ShadowError::TrackedFileNeedsOverlay(path) => format!(
+            "エラー: `{path}` は既に Git に追跡されています。`--phantom` を外して overlay として登録してください"
+        ),
         ShadowError::AlreadyManaged(path) => {
             format!("エラー: `{path}` は既に git-shadow の管理対象です")
         }
@@ -682,12 +794,22 @@ fn format_shadow_error_ja(err: &ShadowError) -> String {
              2. `git status` を確認する\n\
              3. もう一度 `git commit` する"
         ),
+        ShadowError::AutoRestoreConflict(file) => format!(
+            "コミットを止めました: stale lock の自動回復で `{file}` を上書きする可能性があります。\n\
+             対処:\n\
+             1. `{file}` の作業内容を確認する\n\
+             2. 必要なら退避してから `git-shadow restore` を実行する\n\
+             3. その後で `git commit` をやり直す"
+        ),
         ShadowError::NotInitialized => "\
 エラー: git-shadow がまだ初期化されていません。\n\
 対処:\n\
 1. リポジトリで `git-shadow install` を実行する\n\
 2. その後に `git-shadow add ...` や `git commit` をやり直す"
             .to_string(),
+        ShadowError::AddSomeFailed(count) => {
+            format!("エラー: {count} 件のパス登録に失敗しました。上のエラーを確認してください")
+        }
         ShadowError::AlreadySuspended => {
             "エラー: shadow changes は既に suspend されています".to_string()
         }
@@ -711,9 +833,15 @@ fn format_shadow_error_ja(err: &ShadowError) -> String {
 fn format_shadow_error_en(err: &ShadowError) -> String {
     match err {
         ShadowError::NotAGitRepo => "Error: not a Git repository".to_string(),
+        ShadowError::PathDoesNotExist(path) => {
+            format!("Error: `{path}` does not exist")
+        }
         ShadowError::FileNotTracked(path) => {
             format!("Error: `{path}` is not tracked by Git")
         }
+        ShadowError::TrackedFileNeedsOverlay(path) => format!(
+            "Error: `{path}` is already tracked by Git. Remove `--phantom` to register it as overlay"
+        ),
         ShadowError::AlreadyManaged(path) => {
             format!("Error: `{path}` is already managed by git-shadow")
         }
@@ -781,12 +909,22 @@ What to do:\n\
              2. Check `git status`\n\
              3. Run `git commit` again"
         ),
+        ShadowError::AutoRestoreConflict(file) => format!(
+            "Commit blocked: automatic stale-lock recovery would overwrite newer working tree content in `{file}`.\n\
+             What to do:\n\
+             1. Review the current contents of `{file}`\n\
+             2. Save anything you need, then run `git-shadow restore`\n\
+             3. Run `git commit` again"
+        ),
         ShadowError::NotInitialized => "\
 Error: git-shadow is not initialized yet.\n\
 What to do:\n\
 1. Run `git-shadow install` in this repository\n\
 2. Retry `git-shadow add ...` or `git commit`"
             .to_string(),
+        ShadowError::AddSomeFailed(count) => {
+            format!("Error: failed to register {count} path(s); see the errors above")
+        }
         ShadowError::AlreadySuspended => {
             "Error: shadow changes are already suspended".to_string()
         }

--- a/tests/test_commit_cycle.rs
+++ b/tests/test_commit_cycle.rs
@@ -405,7 +405,7 @@ fn install_hooks_for_test(git: &GitRepo) {
     let hooks_dir = git.hooks_dir();
     std::fs::create_dir_all(&hooks_dir).unwrap();
 
-    for name in &["pre-commit", "post-commit", "post-merge"] {
+    for name in &["pre-commit", "post-commit", "post-merge", "post-rewrite"] {
         let content = format!("#!/bin/sh\nexec git-shadow hook {}\n", name);
         std::fs::write(hooks_dir.join(name), content).unwrap();
 

--- a/tests/test_worktree.rs
+++ b/tests/test_worktree.rs
@@ -65,6 +65,7 @@ fn test_install_in_worktree() {
     assert!(hooks_dir.join("pre-commit").exists());
     assert!(hooks_dir.join("post-commit").exists());
     assert!(hooks_dir.join("post-merge").exists());
+    assert!(hooks_dir.join("post-rewrite").exists());
 
     // Hooks should NOT be under worktree's git_dir
     assert!(!wt_repo.git_dir.join("hooks").join("pre-commit").exists());
@@ -204,7 +205,7 @@ fn install_hooks_for_test(git: &GitRepo) {
     let hooks_dir = git.hooks_dir();
     std::fs::create_dir_all(&hooks_dir).unwrap();
 
-    for name in &["pre-commit", "post-commit", "post-merge"] {
+    for name in &["pre-commit", "post-commit", "post-merge", "post-rewrite"] {
         let content = format!("#!/bin/sh\nexec git-shadow hook {}\n", name);
         std::fs::write(hooks_dir.join(name), content).unwrap();
 


### PR DESCRIPTION
## Summary
- add an opt-in `git shadow status --git` view and expand `git-shadow status` so overlay entries show local-only meaning, staged state, and clearer phantom-dir output
- make `git-shadow add` accept multiple paths with tracked/untracked auto-detection while keeping explicit `--overlay` and `--phantom` overrides
- recover safe stale-lock cases automatically and add clean-only auto-rebase handling for `post-merge` and `post-rewrite`
- document the new status/add flow and the practical limitation that Git has no general pre-`add` hook

## Why
Issue #12 highlighted that git-shadow still leaked too much internal state into day-to-day Git usage. Overlay files looked like ordinary `git status` changes, `add` required too much concept knowledge up front, stale locks interrupted commits unnecessarily, and baseline drift after merge/amend needed manual cleanup.

## Impact
- overlay-managed files are easier to interpret during normal work without replacing `git status` by default
- `git-shadow add` fits mixed tracked/untracked local-only setups with less ceremony
- stale commits and post-merge/post-rewrite drift recover more smoothly while staying conservative when overwrite risk exists
- documentation now points users toward the opt-in combined status view and explains where warnings can and cannot happen

## Validation
- `cargo fmt --check`
- `cargo test`
- `cargo clippy -- -D warnings`

Closes #12


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Register multiple files with a single `git-shadow add` command
  * View combined Git and shadow status with the new `--git` flag
  * Automatic stale lock recovery with conflict detection prevents commit issues

* **Improvements**
  * Overlay status now displays Git state and staging information
  * Partial registration failures no longer block multi-file operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->