### PR TITLE
fix: harden shadow state handling, respect core.hooksPath, add uninstall/--json/--version, expand E2E coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,12 @@ jobs:
       - run: cargo clippy -- -D warnings
 
   test:
-    name: Test
-    runs-on: ubuntu-latest
+    name: Test (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - run: cargo test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,19 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: rustup component add rustfmt clippy
+      - run: cargo fmt --check
+      - run: cargo clippy -- -D warnings
+      - run: cargo test
+
   build:
     name: Build (${{ matrix.target }})
+    needs: test
     strategy:
       fail-fast: false
       matrix:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@
 - **Atomic writes** -- All file mutations use tempfile + rename via `fs_util::atomic_write()` to prevent corruption.
 - **PID-based lockfile** -- Uses `libc::kill(pid, 0)` for stale lock detection.
 - **PreCommitTransaction pattern** -- The pre-commit hook tracks state for rollback on failure.
-- **Worktree awareness** -- `GitRepo::discover()` resolves `git_dir` (per-worktree) and `common_dir` (shared). Hooks and `.git/info/exclude` use `common_dir` so they are shared across worktrees. Shadow state (`config.json`, `baselines/`, `stash/`, `lock`) uses `git_dir` so each worktree is independent. Fallback discovery handles Git < 2.31 which lacks `--git-common-dir`. On `install`, if running in a worktree with no existing config, the managed file list is auto-inherited from the main repo (`inherit_from_main_worktree()`): overlay baselines are regenerated from the worktree's HEAD, phantom entries are copied as-is.
+- **Worktree awareness** -- `GitRepo::discover()` resolves `git_dir` (per-worktree) and `common_dir` (shared). Hooks are installed to the effective hooks dir (`effective_hooks_dir()`): it honors `core.hooksPath` when set (resolving relative paths against the worktree root), otherwise falls back to `common_dir/hooks` so hooks are shared across worktrees. `.git/info/exclude` uses `common_dir`. Shadow state (`config.json`, `baselines/`, `stash/`, `suspended/`, `lock`) uses `git_dir` so each worktree is independent. Fallback discovery handles Git < 2.31 which lacks `--git-common-dir`. On `install`, if running in a worktree with no existing config, the managed file list is auto-inherited from the main repo (`inherit_from_main_worktree()`): overlay baselines are regenerated from the worktree's HEAD, phantom entries are copied as-is.
 
 ### Module Structure
 
@@ -35,32 +35,37 @@ src/
   error.rs             # ShadowError (thiserror)
   config.rs            # ShadowConfig, FileEntry, FileType, ExcludeMode
   path.rs              # Path normalization + URL encoding (%25 before %2F)
-  lock.rs              # Lockfile acquire/release/stale detection
+  lock.rs              # Lockfile acquire/release/stale detection (LockStatus incl. Corrupt)
   fs_util.rs           # Atomic write, binary detection, size check
-  git.rs               # GitRepo struct (root, git_dir, common_dir, shadow_dir; hooks_dir())
+  git.rs               # GitRepo struct (root, git_dir, common_dir, shadow_dir; hooks_dir(), effective_hooks_dir())
+  ui.rs                # Locale detection (ja/en) + user-facing message/error formatting
   exclude.rs           # .git/info/exclude section management
   diff_util.rs         # Unified diff formatting (similar crate)
   merge.rs             # 3-way merge via `git merge-file -p --diff3`
   commands/
     install.rs         # Set up hooks + .git/shadow/ structure
+    uninstall.rs       # Remove hooks + shadow state (refuses with active entries unless --force)
     add.rs             # Register overlay or phantom
     remove.rs          # Unregister with confirmation prompt
-    status.rs          # Show managed files, warnings
+    status.rs          # Show managed files, warnings (--json)
     diff.rs            # Show shadow changes as unified diff
-    rebase.rs          # Update baseline with 3-way merge
+    rebase.rs          # Update baseline with 3-way merge (auto_rebase_all for hooks)
     restore.rs         # Recover from interrupted commits
     suspend.rs         # Suspend shadow changes for branch switching
     resume.rs          # Resume suspended changes (with 3-way merge)
-    doctor.rs          # Diagnose hooks, config, stale state
+    doctor.rs          # Diagnose hooks, config, stale state (--json, non-zero exit on issues)
     hook.rs            # Dispatcher for `git-shadow hook <name>`
   hooks/
     pre_commit.rs      # Stash shadow -> restore baseline -> stage
     post_commit.rs     # Restore shadow from stash -> release lock
-    post_merge.rs      # Detect baseline drift, warn user
+    post_merge.rs      # Clean-only auto-rebase of baselines under lock
+    post_rewrite.rs    # Clean-only auto-rebase after amend/rebase (shares auto_rebase_all)
 tests/
-  common/mod.rs        # TestRepo helper
-  test_commit_cycle.rs # E2E: overlay cycle, phantom cycle, rollback
-  test_worktree.rs     # E2E: worktree discovery, install, commit cycle
+  common/mod.rs           # TestRepo helper
+  test_commit_cycle.rs    # E2E: overlay/phantom/phantom-dir cycles, rollback, mixed
+  test_worktree.rs        # E2E: worktree discovery, install, commit cycle, config inheritance
+  test_git_operations.rs  # E2E: amend, rebase, merge, cherry-pick, pathspec, live-lock
+  test_localized_errors.rs # E2E: locale-aware messages, --version, --json, uninstall
 ```
 
 ### Path Encoding
@@ -84,11 +89,11 @@ cargo fmt --check               # Must pass
 ### CI
 
 GitHub Actions runs on every push to `main` and on pull requests:
-- **fmt** -- `cargo fmt --check`
-- **clippy** -- `cargo clippy -- -D warnings`
-- **test** -- `cargo test`
+- **fmt** -- `cargo fmt --check` (ubuntu)
+- **clippy** -- `cargo clippy -- -D warnings` (ubuntu)
+- **test** -- `cargo test` on an OS matrix (`ubuntu-latest`, `macos-latest`)
 
-Configuration: `.github/workflows/ci.yml`
+Configuration: `.github/workflows/ci.yml`. Releases (`.github/workflows/release.yml`) run the test job first and gate the build/publish jobs on it (`needs: test`).
 
 ### Pre-commit Hook
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -14,6 +14,7 @@ Git リポジトリ内の**ローカル限定の変更**を管理する CLI ツ�
 |------|------|-----|
 | **overlay** | 既存のトラッキング済みファイルにローカル変更を重ねる | 共有の `docker-compose.yml` に個人用デバッグ設定を追加 |
 | **phantom** | リポジトリに存在しないファイルをローカルだけで作成する | `scripts/local-setup.sh` をローカル限定で作成 |
+| **phantom dir** | ディレクトリ全体をローカル限定で管理する（exclude のみ、stash/restore なし） | ローカル限定の `.claude/` ディレクトリを常にコミット対象外にする |
 
 ## インストール
 
@@ -71,17 +72,20 @@ git show HEAD:docker-compose.yml  # クリーンなチーム用の内容のみ
 
 | コマンド | 説明 |
 |---------|------|
-| `git-shadow install` | Git hooks のセットアップ (pre-commit, post-commit, post-merge, post-rewrite) |
+| `git-shadow install` | Git hooks のセットアップ (pre-commit, post-commit, post-merge, post-rewrite)。`core.hooksPath` を尊重 |
+| `git-shadow uninstall [--force]` | hooks・exclude・state を削除。`--force` は管理対象が残っていても overlay を復元して削除 |
 | `git-shadow add <file>...` | tracked は overlay、既存の untracked path は phantom として自動登録 |
 | `git-shadow add --phantom <file>...` | ローカル限定ファイル/ディレクトリを phantom として強制登録 |
 | `git-shadow remove <file>` | shadow 管理から解除 |
-| `git-shadow status [--git]` | 管理対象ファイルの一覧と状態を表示。`--git` で `git status --short --branch` も先に表示 |
+| `git-shadow status [--git] [--json]` | 管理対象ファイルの一覧と状態を表示。`--git` で `git status --short --branch` も先に表示。`--json` はスクリプト向けの安定した英語 JSON を出力 |
 | `git-shadow diff [file]` | shadow 変更の差分を表示 |
 | `git-shadow rebase [file]` | ベースラインを更新し shadow 変更を再適用 (3-way merge) |
 | `git-shadow restore [file]` | 中断されたコミットやクラッシュからの復旧 |
 | `git-shadow suspend` | ブランチ切替のために shadow 変更を一時退避 |
 | `git-shadow resume` | 退避した shadow 変更を復元（必要に応じて 3-way merge） |
-| `git-shadow doctor` | hooks・設定の整合性・残留状態を診断 |
+| `git-shadow doctor [--json]` | hooks・設定の整合性・残留状態を診断。問題があれば非ゼロで終了。`--json` は安定した英語 JSON を出力 |
+
+`git-shadow --version` でインストール済みのバージョンを表示します。
 
 ## 仕組み
 
@@ -108,7 +112,7 @@ git show HEAD:docker-compose.yml  # クリーンなチーム用の内容のみ
 
 ## ドキュメント
 
-- [詳細な使い方ガイド](docs/usage.ja.md)
+- [詳細な使い方ガイド](docs/usage.ja.md) | [English](docs/usage.md)
 - [要件定義](docs/requirements.md)
 
 ## 動作要件

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Sometimes you need personal changes to shared files — debug settings in a conf
 |------|-------------|---------|
 | **overlay** | Layer local changes on top of an existing tracked file | Add personal debug settings to a shared `docker-compose.yml` |
 | **phantom** | Create a file that exists only locally and is never committed | Create a local-only `scripts/local-setup.sh` for your environment |
+| **phantom dir** | Manage an entire directory that exists only locally (exclude-only, no stash/restore) | Keep a local-only `.claude/` directory out of every commit |
 
 ## Installation
 
@@ -71,17 +72,20 @@ git show HEAD:docker-compose.yml  # clean, team-only content
 
 | Command | Description |
 |---------|-------------|
-| `git-shadow install` | Set up Git hooks (pre-commit, post-commit, post-merge, post-rewrite) |
+| `git-shadow install` | Set up Git hooks (pre-commit, post-commit, post-merge, post-rewrite); respects `core.hooksPath` |
+| `git-shadow uninstall [--force]` | Remove hooks, exclude entries, and state; `--force` restores overlays even when files are still managed |
 | `git-shadow add <file>...` | Register tracked files as overlays and existing untracked paths as phantoms automatically |
 | `git-shadow add --phantom <file>...` | Force local-only files/directories to be phantoms |
 | `git-shadow remove <file>` | Unregister a file from shadow management |
-| `git-shadow status [--git]` | Show managed files and their state, optionally prefixed by `git status --short --branch` |
+| `git-shadow status [--git] [--json]` | Show managed files and their state, optionally prefixed by `git status --short --branch`; `--json` emits stable English JSON for scripting |
 | `git-shadow diff [file]` | Show shadow changes as a unified diff |
 | `git-shadow rebase [file]` | Update baseline after upstream changes (3-way merge) |
 | `git-shadow restore [file]` | Recover from interrupted commits or crashes |
 | `git-shadow suspend` | Suspend shadow changes for branch switching |
 | `git-shadow resume` | Resume suspended shadow changes (with 3-way merge if needed) |
-| `git-shadow doctor` | Diagnose hooks, config integrity, and stale state |
+| `git-shadow doctor [--json]` | Diagnose hooks, config integrity, and stale state; exits non-zero when issues are found; `--json` emits stable English JSON |
+
+`git-shadow --version` prints the installed version.
 
 ## How It Works
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1,4 +1,4 @@
-# git-shadow 要件定義 v4
+# git-shadow 要件定義 v5
 
 ## 概要
 
@@ -51,11 +51,13 @@ Rust（シングルバイナリ配布）
 
 ### `git-shadow install`
 
-Git hooks（pre-commit, post-commit, post-merge）をセットアップする。
+Git hooks（pre-commit, post-commit, post-merge, post-rewrite）をセットアップする。
 
 ```bash
 git-shadow install
 ```
+
+`core.hooksPath` が設定されている場合（Husky, lefthook, 独自の `dev-hooks/` 等）、既定の `common_dir/hooks/` ではなく、その有効なディレクトリに hooks を配置する。既定のディレクトリに置くと発火しないためである。
 
 #### 既存 hook との共存
 
@@ -83,14 +85,31 @@ fi
 
 既存 hook が失敗（非ゼロ exit）した場合、commit は中断され post-commit が走らない。この場合も stash/lock が残るため、`git-shadow restore` で復旧できる。
 
+### `git-shadow uninstall`
+
+git-shadow の hooks・exclude エントリ・state を削除する。
+
+```bash
+git-shadow uninstall
+git-shadow uninstall --force
+```
+
+- 有効な hooks ディレクトリ（`core.hooksPath` を尊重）から git-shadow の hooks を削除し、install 時に退避した `<hook>.pre-shadow` backup を復元する。
+- `.git/info/exclude` の管理セクションを、このワークツリー以外のワークツリーの config の和集合から再生成する（他ワークツリーが依存するエントリは保持し、このワークツリー固有のエントリだけを削除する）。
+- このワークツリーの shadow state（`git_dir` 配下の `.git/shadow/`）を削除する。
+- 安全のため、次の場合は実行を拒否する:
+  - 管理対象ファイルが残っている場合（件数を示すエラーで停止する）。`--force` を指定すると overlay をベースラインに復元してから state を削除する（phantom ファイルはディスク上に残す）。
+  - commit が進行中の場合（stash 残骸、または別の live プロセスが lock を保持）。この場合は `--force` の有無に関わらず拒否する。
+
 ### `git-shadow hook <hook-name>`
 
-hook から呼び出される内部サブコマンド。pre-commit / post-commit / post-merge の各処理を実行する。hook ファイルから呼ばれることを前提とし、ユーザーが直接実行することは想定しない。
+hook から呼び出される内部サブコマンド。pre-commit / post-commit / post-merge / post-rewrite の各処理を実行する。hook ファイルから呼ばれることを前提とし、ユーザーが直接実行することは想定しない。
 
 ```bash
 git-shadow hook pre-commit
 git-shadow hook post-commit
 git-shadow hook post-merge
+git-shadow hook post-rewrite
 ```
 
 ### `git-shadow doctor`
@@ -106,10 +125,14 @@ git-shadow doctor
 - hook ファイルが存在するか
 - hook ファイルに実行権限があるか
 - hook ファイルの内容が `git-shadow hook` を呼び出しているか
+- hooks が inert でないか（既定の hooks ディレクトリに hooks があるのに `core.hooksPath` が別を指しており発火しない状態を検出する）
 - 他の hook マネージャー（Husky, pre-commit, lefthook 等）との競合がないか
 - config.json の整合性（管理対象ファイルが存在するか等）
 - stash に残留ファイルがないか（残留している場合は「前回の commit が途中で中断された可能性があります。`git-shadow restore` を実行してください」と案内する）
 - lockfile が残っていないか（残っている場合は PID を確認し、プロセスが存在しなければ stale lock として `git-shadow restore` を案内する）
+- suspend 状態か、また worktree 環境で未初期化でないか
+
+診断結果は issues（壊れているもの）と warnings（注意が必要なもの）に分ける。**issue が 1 件以上ある場合は非ゼロの exit code で終了する**（スクリプトや CI で判定に使える）。warning のみの場合は exit code 0 とする。`--json` フラグを指定すると、ロケールに関わらず安定した英語の JSON（`ok`, `issues`, `warnings`）を出力し、人間向け出力は抑制する。
 
 ### `git-shadow add <file>`
 
@@ -219,6 +242,11 @@ git-shadow status
 | ベースラインのコミットがずれている | `baseline_commit` と HEAD の比較 |
 | phantom の `--no-exclude` 運用で `git status` に表示されている | `exclude_mode` が `none` の phantom がある |
 
+#### `--git` / `--json` フラグ
+
+- `--git`: shadow のサマリの前に `git status --short --branch` を表示する（opt-in の統合表示）。デフォルトでは `git status` を置き換えない。
+- `--json`: ロケールに関わらず安定した英語の JSON を出力し、人間向け出力は抑制する。`git_state` は `clean` / `modified` / `staged` / `partially_staged`、`warnings` は `stash_remaining` / `stale_lock` 等の安定したトークンを使う。
+
 ### `git-shadow diff [file]`
 
 shadow 変更の差分を表示する。
@@ -270,6 +298,37 @@ git-shadow restore CLAUDE.md
 - pre-commit は成功したが commit 自体が不成立だった場合（commit-msg での中断、エディタを閉じた中断等）
 - 既存 hook のチェーン実行が失敗して commit が中断された場合
 - `git stash` や `git checkout` で shadow 変更が失われた場合（stash に前回退避分が残っていれば復元できる）
+- `restore` は別の live プロセスが lock を保持している場合は実行を拒否し、進行中の作業を上書きしない。所有プロセスが存在しない（stale な）lock だけをクリーンアップする。
+
+### `git-shadow suspend`
+
+ブランチ切り替えのために shadow 変更を一時退避する。overlay の変更はワーキングツリーを変更するため `git checkout` を妨げることがあり、それをクリーンにするためのコマンド。
+
+```bash
+git-shadow suspend
+```
+
+処理フロー:
+
+1. 各 overlay のワーキングツリー内容を `.git/shadow/suspended/`（commit サイクル用の `stash/` とは別）に保存し、ベースラインをワーキングツリーに復元する。
+2. 各 phantom（ディレクトリ以外）のファイルを `suspended/` に保存し、ワーキングツリーから削除する。
+3. `config.suspended = true` にする。
+4. ガード: すでに suspend 済み、lock 保持中、stash 残骸がある場合は拒否する。処理の途中で失敗した場合はロールバックする（部分的な退避状態を残さない）。
+
+### `git-shadow resume`
+
+suspend した shadow 変更を復元する。
+
+```bash
+git-shadow resume
+```
+
+処理フロー:
+
+1. ベースラインが変わっていなければ、退避内容をそのまま復元する。
+2. ベースラインが変わっている（別ブランチ等）場合は 3-way merge（旧ベースライン / 退避内容 / 現在の HEAD）で再適用し、コンフリクト時はマーカーを書き込んで手動解決を促す。
+3. suspend 中にワーキングツリーで編集されたファイルは、上書きを避けるため resume を拒否する（`.git/shadow/suspended/` の内容と統合してから再実行する）。
+4. `suspended/` をクリーンアップし、`config.suspended = false` にする。
 
 ## 内部データ構造
 
@@ -283,7 +342,9 @@ git-shadow restore CLAUDE.md
 ├── lock                 # 実行中フラグ（lockfile、PID とタイムスタンプを記録）
 ├── baselines/           # overlay 対象のベースライン（HEAD の内容のスナップショット）
 │   └── <url_encoded_path>
-└── stash/               # pre-commit 時の退避先
+├── stash/               # pre-commit 時の退避先
+│   └── <url_encoded_path>
+└── suspended/           # suspend 時の退避先（ブランチ切り替え用、stash とは別）
     └── <url_encoded_path>
 ```
 
@@ -293,8 +354,8 @@ git worktree を使用する場合、Git ディレクトリは `git_dir`（ワ�
 
 | 用途 | 参照先 | 理由 |
 |------|--------|------|
-| shadow 状態（`config.json`, `baselines/`, `stash/`, `lock`） | `git_dir` 配下 | ワーキングツリーごとに独立した状態を持つ |
-| hooks（`pre-commit`, `post-commit`, `post-merge`） | `common_dir/hooks/` | すべてのワーキングツリーで共有する |
+| shadow 状態（`config.json`, `baselines/`, `stash/`, `suspended/`, `lock`） | `git_dir` 配下 | ワーキングツリーごとに独立した状態を持つ |
+| hooks（`pre-commit`, `post-commit`, `post-merge`, `post-rewrite`） | `common_dir/hooks/`（`core.hooksPath` が設定されていればそちら） | すべてのワーキングツリーで共有する |
 | `.git/info/exclude`（phantom の除外設定） | `common_dir/info/exclude` | すべてのワーキングツリーで共有する |
 
 `GitRepo::discover()` は `git rev-parse --path-format=absolute --show-toplevel --git-dir --git-common-dir` で3つのパスを取得する。`--git-common-dir` は Git 2.5.0（2015年）で導入、`--path-format=absolute` は Git 2.31.0（2021年）で導入された。Git 2.31 未満では `--path-format=absolute` がサポートされないため、フォールバック処理で相対パスを手動解決する。`--git-common-dir` も使えない場合は `git_dir` を `common_dir` として扱う（通常リポジトリと同等の動作）。
@@ -393,19 +454,21 @@ git worktree を使用する場合、Git ディレクトリは `git_dir`（ワ�
     - 失敗したファイルの一覧を表示し、git-shadow restore の実行を案内する
 ```
 
-### post-merge
+### post-merge / post-rewrite
 
-`git pull` や `git merge` の直後に実行される。ベースラインのずれを検出する。
+`git pull` / `git merge`（post-merge）や `git commit --amend` / `git rebase`（post-rewrite）の直後に実行される。ベースラインのずれを検出し、**クリーン時限定の自動 rebase** を行う。
 
 ```
 overlay ファイルごとに:
   1. config.json の baseline_commit と現在の HEAD を比較する
-  2. 対象ファイルの HEAD の内容がベースラインと異なっていれば警告を表示する:
-     "⚠ CLAUDE.md のベースラインが古くなっています。
-      git-shadow rebase CLAUDE.md を実行してください"
+  2. 対象ファイルの HEAD の内容がベースラインと異なっていれば、3-way merge で
+     新ベースラインに shadow 変更を再適用する（auto_rebase）
+  3. クリーンにマージできた場合はベースラインと shadow 変更を自動更新する
+  4. コンフリクトが発生した場合は自動 rebase をスキップし、
+     "git-shadow rebase <file> を実行してください" と警告する
 ```
 
-自動 rebase は行わない。ユーザーが明示的に `git-shadow rebase` を実行する。
+自動 rebase はコンフリクトが起きない場合に限る。コンフリクトする場合はユーザーが明示的に `git-shadow rebase` で解決する。hook 実行時に別の live プロセスが lock を保持している場合は、安全のため自動 rebase をスキップする。
 
 ### pre-commit 失敗時のロールバック
 
@@ -492,7 +555,7 @@ git worktree 環境でも正常に動作する。
 
 - **hooks は共有**: `git-shadow install` で作成される hook スクリプトは `common_dir/hooks/` に配置され、すべてのワーキングツリーで共有される。ただし、hooks の共有はフック発火のみに関わる。各ワーキングツリーでは `git-shadow install` を実行して `shadow/` ディレクトリ（`baselines/`、`stash/` 等）を初期化する必要がある。
 - **install 時の自動継承**: ワーキングツリーで `git-shadow install` を実行した際、メインリポジトリに `config.json` と shadow 管理対象ファイルが存在し、かつワーキングツリーに `config.json` がまだ存在しない場合、ファイルリストを自動的に継承する。overlay のベースラインはワーキングツリーの HEAD から再生成し、phantom エントリはそのままコピーする。この条件を満たす場合、`git-shadow add` を個別に実行する必要はない。
-- **shadow 状態は独立**: `config.json`、`baselines/`、`stash/`、`lock` は各ワーキングツリーの `git_dir` 配下に保存される。ワーキングツリーごとに異なるファイルを shadow 管理できる。継承後にファイルの追加・削除（`git-shadow add` / `git-shadow remove`）もワーキングツリーごとに独立して行える。
+- **shadow 状態は独立**: `config.json`、`baselines/`、`stash/`、`suspended/`、`lock` は各ワーキングツリーの `git_dir` 配下に保存される。ワーキングツリーごとに異なるファイルを shadow 管理できる。継承後にファイルの追加・削除（`git-shadow add` / `git-shadow remove`）もワーキングツリーごとに独立して行える。
 - **doctor による検出**: `git-shadow doctor` はワーキングツリー環境を検出し、`shadow/` ディレクトリが未初期化の場合は警告を表示して `git-shadow install` の実行を案内する。
 
 ### Git バージョン要件
@@ -506,7 +569,15 @@ git worktree 環境でも正常に動作する。
 以下は初期実装には含めない。
 
 - チームでの共有機能（テンプレート、export/import 等）
-- post-checkout hook によるブランチ切り替え時の自動対応（ただし status と pre-commit の不整合チェックでずれは検出できる）
-- post-merge での自動 rebase（`--auto` フラグ）
+- post-checkout hook によるブランチ切り替え時の自動対応（ただし status と pre-commit の不整合チェック、および `git-shadow suspend` / `resume` でずれに対応できる）
 - `git-shadow remove --keep`（shadow 変更を保持したまま管理解除し、通常のコミット対象にする）
 - GUI / TUI
+
+> 注: 当初「スコープ外」としていた post-merge での自動 rebase は、**クリーン時限定の自動 rebase** として実装済み（v5）。コンフリクト時は手動 `git-shadow rebase` を促す。ブランチ切り替え支援は `git-shadow suspend` / `resume` として実装済み（v5）。
+
+## 改訂履歴
+
+| バージョン | 主な変更点 |
+|---|---|
+| v5 | 実装に合わせて仕様を同期: `git-shadow suspend` / `resume` を追加、post-merge / post-rewrite でのクリーン時限定 自動 rebase を明記（旧「自動 rebase は行わない」を更新）、post-rewrite hook を追加、`git-shadow uninstall` を追加、`core.hooksPath` 対応、doctor の非ゼロ終了コードと inert hooks 検出、status / doctor の `--json` 出力を追記。 |
+| v4 | git worktree 対応（per-worktree state と共有 hooks/exclude、install 時の自動継承）。 |

--- a/docs/usage.ja.md
+++ b/docs/usage.ja.md
@@ -10,6 +10,7 @@ cargo install --path .
 
 # 確認
 git-shadow --help
+git-shadow --version
 ```
 
 ## セットアップ
@@ -23,20 +24,44 @@ git-shadow install
 
 以下が作成されます:
 - `.git/shadow/` ディレクトリ (baselines, stash, config)
-- Git hooks: `pre-commit`, `post-commit`, `post-merge`
+- Git hooks: `pre-commit`, `post-commit`, `post-merge`, `post-rewrite`
 
 既存の hook がある場合は `<hook>.pre-shadow` にリネームされ、git-shadow の処理後にチェーン実行されます。
+
+> **`core.hooksPath`**: リポジトリで `core.hooksPath`（Husky、lefthook、独自の `dev-hooks/` など）が設定されている場合、`install` は hooks を実際に発火する有効なディレクトリに配置し、`note: core.hooksPath (.husky) is set, so hooks were installed into <path>` のようなメッセージを表示します。既定のディレクトリに hooks があるのに `core.hooksPath` が別を指している（＝発火せず黙って無視される）場合、`git-shadow doctor` が issue として報告します。
 
 > **worktree**: `git worktree` を使用している場合は、各ワークツリーで `git-shadow install` を個別に実行してください。メインリポジトリに shadow 管理対象ファイルがある場合、`install` 時に自動的にファイルリストが継承されます（overlay のベースラインはワークツリーの HEAD から再生成、phantom エントリはそのままコピー）。詳細は [git worktree 対応](#git-worktree-対応) を参照してください。
 
 ## ファイルの管理
+
+### ファイルの追加
+
+`git-shadow add` は 1 つ以上のパスを受け取り、それぞれの管理方法を自動で判定します:
+
+- **トラッキング済みファイル** は **overlay**（コミット済み内容に重ねるローカル変更）になります。
+- **既存の未追跡パス** は **phantom**（自分のマシンだけに存在するファイルまたはディレクトリ）になります。
+
+```bash
+# 複数のファイルを一度に追加 — それぞれ自動で判定される
+git-shadow add docker-compose.yml scripts/local-setup.sh .env.local
+```
+
+判定できないパス（トラッキングされておらず、ディスク上にも存在しない）があった場合、そのパスはエラーになり、残りのパスは処理が続行されます。1 つでも失敗すると、コマンドは非ゼロで終了します。
+
+**オプション:**
+- `--overlay` — 指定したパスをすべて overlay として強制登録（ファイルはトラッキング済みである必要があります）
+- `--phantom` — 指定したパスをすべて phantom として強制登録（パスはトラッキングされていない必要があります）
+- `--no-exclude` — `.git/info/exclude` への追加をスキップ（phantom のみ）。`git status` には未追跡ファイルとして表示されますが、pre-commit hook によりコミットからは除外されます。
+- `--force` — overlay の 1MB ファイルサイズ上限を無視
+
+`--overlay` と `--phantom` は同時に指定できません。
 
 ### Overlay: トラッキング済みファイルへのローカル変更
 
 チームが既にトラッキングしているファイルに個人的な内容を追記したい場合に使います。
 
 ```bash
-# トラッキング済みファイルを登録
+# トラッキング済みファイルを登録（overlay として自動判定）
 git-shadow add docker-compose.yml
 
 # 自由に編集 — あなたの変更は「shadow 変更」になる
@@ -48,25 +73,17 @@ echo "  # 個人用デバッグポート" >> docker-compose.yml
 2. 元の内容（ベースライン）がコミットされる
 3. コミット直後にあなたの追記が復元される
 
-**オプション:**
-- `--force` — 1MB のファイルサイズ上限をスキップ
-
 ### Phantom: ローカル限定ファイル
 
 自分のマシンだけに存在するファイルを管理したい場合に使います。
 
 ```bash
-# 新しいローカル限定ファイルを作成して登録
+# 新しいローカル限定ファイルを作成して登録（phantom として自動判定）
 echo "#!/bin/bash" > scripts/local-setup.sh
 git-shadow add scripts/local-setup.sh
 ```
 
-デフォルトでは `.git/info/exclude` に追加され、`git status` に表示されなくなります。
-
-**オプション:**
-- `--overlay` — 指定したパスをすべて overlay として強制登録
-- `--phantom` — 指定したパスをすべて phantom として強制登録
-- `--no-exclude` — `.git/info/exclude` への追加をスキップ。`git status` には未追跡ファイルとして表示されますが、pre-commit hook によりコミットからは除外されます。
+デフォルトでは `.git/info/exclude` に追加され、`git status` に表示されなくなります。`--no-exclude` でこの追加をスキップできます。
 
 #### Phantom ディレクトリ
 
@@ -93,6 +110,39 @@ git-shadow remove docker-compose.yml
 
 解除前に確認プロンプトが表示されます。`--force` でスキップできます（非対話環境では必須）。
 
+## アンインストール
+
+リポジトリから git-shadow を完全に削除するには:
+
+```bash
+git-shadow uninstall
+```
+
+以下の処理が行われます:
+- 有効な hooks ディレクトリ（`core.hooksPath` を尊重）から git-shadow の hooks を削除し、install 時に退避した `<hook>.pre-shadow` backup を復元します
+- このワークツリーが所有する `.git/info/exclude` の管理セクションのエントリを削除します（他のワークツリーが所有するエントリは保持されます）
+- このワークツリーの shadow state（`.git/shadow/`）を削除します
+
+安全のため、`uninstall` は次の 2 つの状況では実行を**拒否**します:
+- **管理対象ファイルが残っている** — 件数を示すエラーで停止します。`git-shadow remove <file>` で個別に解除するか、`--force` を付けて再実行してください。
+- **コミットが進行中** — stash の残骸や、別の live プロセスが保持している lock があると、commit サイクルが進行中と判断され、state を消すと作業を失う可能性があります。
+
+```bash
+# 管理対象が残っていても overlay を復元して state を削除する
+git-shadow uninstall --force
+```
+
+`--force` を付けると、overlay ファイルはベースラインの内容に復元され（shadow 変更は破棄）、件数が `restored baselines to the working tree for 1 overlay(s)` のように報告されます。phantom ファイルはあなたのローカル限定ファイルなので、ディスク上でそのまま残されます。成功時には `git-shadow uninstalled (hooks, exclude entries, and state removed)` と表示されます。
+
+### 手動での削除
+
+バイナリが使えず、手作業で git-shadow を削除する必要がある場合:
+
+1. 有効な hooks ディレクトリ（`.git/hooks/` または `core.hooksPath`）で、`git-shadow hook` を呼び出す `pre-commit`・`post-commit`・`post-merge`・`post-rewrite` スクリプトを削除します。`<hook>.pre-shadow` backup があれば `<hook>` に戻します。
+2. コミット済み内容に戻したい overlay ファイルを復元します（例: `git restore --source=HEAD -- <file>`）。
+3. `.git/shadow/` を削除します。
+4. `.git/info/exclude` から git-shadow の管理セクション（マーカーコメントで囲まれた範囲）を削除します。
+
 ## 状態の確認と差分表示
 
 ### Status
@@ -116,6 +166,33 @@ git shadow status --git
 
 `git status --short --branch` を先に表示し、その後に shadow 管理対象の意味づけを表示します。デフォルトでは `git status` 自体は置き換えません。
 
+スクリプトで使う場合は `--json` を指定します:
+
+```bash
+git-shadow status --json
+```
+
+安定した英語（非ローカライズ）の JSON を出力し、人間向けの出力は抑制されます。キーはパース向けの安定した識別子です。例えば `git_state` は `clean`・`modified`・`staged`・`partially_staged` のいずれか、`warnings` には `stash_remaining` や `stale_lock` などのトークンが入ります:
+
+```json
+{
+  "suspended": false,
+  "warnings": [],
+  "files": [
+    {
+      "path": "docker-compose.yml",
+      "type": "overlay",
+      "exists": true,
+      "baseline_commit": "f5fb751...",
+      "shadow_added": 1,
+      "shadow_removed": 0,
+      "git_state": "modified",
+      "baseline_outdated": false
+    }
+  ]
+}
+```
+
 ### Diff
 
 ```bash
@@ -131,15 +208,19 @@ git-shadow diff docker-compose.yml
 
 ## アップストリームの変更への対応
 
-overlay をかけているファイルがチームによって更新された場合（`git pull` 後など）:
+overlay をかけているファイルがチームによって更新された場合（`git pull` 後など）、`post-merge` と `post-rewrite` hook が自動的に実行されます:
+
+- **クリーンなマージ** — ベースラインと shadow 変更が自動的に再適用されます（クリーン時限定の自動 rebase）。操作は不要です。
+- **コンフリクト** — 自動 rebase はスキップされ、`git-shadow rebase <file>` で手動解決するよう警告されます。
+
+手動 rebase が必要な場合は明示的に実行します:
 
 ```bash
-# post-merge hook が警告を表示:
-# "warning: baseline for docker-compose.yml is outdated. Run `git-shadow rebase docker-compose.yml`"
-
 # ベースラインを更新し shadow 変更を再適用
 git-shadow rebase docker-compose.yml
 ```
+
+hook 実行時に別の live プロセスが lock を保持している場合、安全のため自動 rebase はスキップされます。後から自分で `git-shadow rebase` を実行してください。
 
 rebase は 3-way merge を実行します:
 1. 旧ベースライン（共通祖先）
@@ -236,6 +317,19 @@ git-shadow restore docker-compose.yml
 
 `git commit` 中に stale lock が見つかった場合も、作業ツリーを安全に復元できると判断できるときは自動回復を試みます。新しい内容を上書きする恐れがある場合だけ、従来どおり手動 `git-shadow restore` が必要です。
 
+`restore` は、別の **live** プロセスが lock を保持している場合（実際の commit や hook が進行中の場合）は実行を拒否するため、他のプロセスの作業を上書きすることはありません。所有プロセスが既に存在しない（stale な）lock だけをクリーンアップします。
+
+### トラブルシューティング
+
+| 症状 | 原因 | 対処 |
+|------|------|------|
+| shadow 変更がコミットされる / hooks が実行されない | `core.hooksPath` が hooks の場所とは別を指しており、hooks が発火しない | `git-shadow install` を再実行する（有効な hooks ディレクトリにインストールされます）。`git-shadow doctor` が issue として報告します。 |
+| `git commit` が "another git-shadow process still holds the lock" でブロックされる | 別の live な commit / hook が実行中 | 終わるまで待つ。実際には何も動いていないなら lock は stale なので `git-shadow restore` を実行する。 |
+| `git commit` が "leftover files remain in `.git/shadow/stash/`" でブロックされる | 前回の commit が中断された | `git-shadow restore` を実行してから、もう一度 commit する。 |
+| `git-shadow restore` が実行を拒否する | live プロセスが lock を保持している | そのプロセスの終了を待つ。restore は stale な lock だけを片付けます。 |
+| `git-shadow resume` が "was edited in the working tree while suspended" でブロックされる | suspend 後にファイルを編集したため、resume すると編集が上書きされる | ファイルを確認し、残したい内容を退避し、`.git/shadow/suspended/` の内容と統合してから、もう一度 `git-shadow resume` を実行する。 |
+| `git-shadow doctor` が非ゼロで終了する | 1 件以上の issue を検出した（壊れた hooks、baseline の欠落、inert な hooks など） | `issues:` のリストを読み、それぞれ対処する。warning だけなら非ゼロにはなりません。 |
+
 ## 診断
 
 ```bash
@@ -243,10 +337,31 @@ git-shadow doctor
 ```
 
 チェック項目:
-- Hook ファイルの存在、実行権限、内容
+- Hook ファイルの存在、実行権限、内容、および inert でないこと（既定のディレクトリに hooks があるのに `core.hooksPath` が別を指していないか）
 - 競合する hook マネージャーの検出 (Husky, pre-commit, lefthook)
 - config の整合性（管理対象ファイルとベースラインの存在確認）
 - stash 残留や stale lock の有無
+- suspend 状態、worktree の初期化
+
+検出結果は **issues**（赤 `✗`、壊れているもの）と **warnings**（黄 `⚠`、注意が必要なもの）に分かれます。
+
+**終了コード:** `doctor` は 1 件以上の issue を検出すると非ゼロで終了します（例: `Error: doctor found 4 issue(s)`）。これによりスクリプトや CI で判定に使えます。warning だけの場合は終了コード 0 のままです。
+
+スクリプトで使う場合は `--json` を指定します:
+
+```bash
+git-shadow doctor --json
+```
+
+安定した英語（非ローカライズ）の JSON を出力し、人間向けの出力は抑制されます。`ok` フィールドは issue がある場合に `false` になります（非ゼロの終了コードと一致します）:
+
+```json
+{
+  "ok": true,
+  "issues": [],
+  "warnings": []
+}
+```
 
 ## データ保存先
 
@@ -357,6 +472,7 @@ worktree を使う場合、suspend/resume は不要です（各 worktree が独�
 | worktree を削除 | `git worktree remove <path>`（shadow 状態も消える） |
 | 状態を確認 | `git-shadow status` / `git-shadow doctor` |
 | ブランチ切替（worktree なし） | `git-shadow suspend` → checkout → `git-shadow resume` |
+| リポジトリから git-shadow を削除 | `git-shadow uninstall`（または `--force`） |
 
 ## 注意事項
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -10,6 +10,7 @@ cargo install --path .
 
 # Verify
 git-shadow --help
+git-shadow --version
 ```
 
 ## Setup
@@ -23,20 +24,44 @@ git-shadow install
 
 This creates:
 - `.git/shadow/` directory (baselines, stash, config)
-- Git hooks: `pre-commit`, `post-commit`, `post-merge`
+- Git hooks: `pre-commit`, `post-commit`, `post-merge`, `post-rewrite`
 
 If hooks already exist, they are renamed to `<hook>.pre-shadow` and chained after git-shadow's processing.
+
+> **`core.hooksPath`**: If your repository sets `core.hooksPath` (e.g., Husky, lefthook, or a custom `dev-hooks/` directory), `install` places its hooks into that effective directory so they actually run, and prints a note such as `note: core.hooksPath (.husky) is set, so hooks were installed into <path>`. `git-shadow doctor` reports an issue if hooks are installed in the default directory while `core.hooksPath` points elsewhere (they would be inert and silently skipped).
 
 > **Worktrees**: If you use `git worktree`, run `git-shadow install` separately in each worktree. If the main repo already has shadow-managed files, `install` automatically inherits the file list (overlay baselines are regenerated from the worktree's HEAD; phantom entries are copied as-is). See [git worktree Support](#git-worktree-support) for details.
 
 ## Managing Files
+
+### Adding Files
+
+`git-shadow add` accepts one or more paths and automatically chooses how to manage each one:
+
+- **Tracked files** become **overlays** (local changes layered on top of committed content).
+- **Existing untracked paths** become **phantoms** (files or directories that live only on your machine).
+
+```bash
+# Add several files at once — each is classified automatically
+git-shadow add docker-compose.yml scripts/local-setup.sh .env.local
+```
+
+If any path cannot be classified (it is neither tracked nor exists on disk), that path fails with an error and the remaining paths are still processed; the command exits non-zero when at least one path failed.
+
+**Options:**
+- `--overlay` — Force overlay registration for all given paths (the file must be tracked)
+- `--phantom` — Force phantom registration for all given paths (the path must not be tracked)
+- `--no-exclude` — Skip the `.git/info/exclude` entry (phantom only). The file will appear in `git status` as untracked but is still excluded from commits by the pre-commit hook.
+- `--force` — Ignore the 1MB overlay file size limit
+
+`--overlay` and `--phantom` are mutually exclusive.
 
 ### Overlay: Local Changes on Tracked Files
 
 Use overlays when you want to add personal content to a file that the team already tracks.
 
 ```bash
-# Register a tracked file
+# Register a tracked file (auto-detected as an overlay)
 git-shadow add docker-compose.yml
 
 # Edit freely — your changes are "shadow" changes
@@ -48,25 +73,17 @@ echo "  # my debug port override" >> docker-compose.yml
 2. The original (baseline) content is committed
 3. Your additions are restored immediately after
 
-**Options:**
-- `--force` — Skip the 1MB file size limit
-
 ### Phantom: Local-Only Files
 
 Use phantoms for files that should exist only on your machine.
 
 ```bash
-# Create and register a new local-only file
+# Create a new local-only file, then register it (auto-detected as a phantom)
 echo "#!/bin/bash" > scripts/local-setup.sh
 git-shadow add scripts/local-setup.sh
 ```
 
-By default, phantom files are added to `.git/info/exclude` to hide them from `git status`.
-
-**Options:**
-- `--overlay` — Force overlay registration for all given paths
-- `--phantom` — Force phantom registration for all given paths
-- `--no-exclude` — Skip the `.git/info/exclude` entry. The file will appear in `git status` as untracked but will still be excluded from commits by the pre-commit hook.
+By default, phantom files are added to `.git/info/exclude` to hide them from `git status`. Use `--no-exclude` to skip that entry.
 
 #### Phantom Directories
 
@@ -93,6 +110,39 @@ git-shadow remove docker-compose.yml
 
 A confirmation prompt is shown before removal. Use `--force` to skip it (required in non-interactive environments).
 
+## Uninstalling
+
+To remove git-shadow from a repository entirely:
+
+```bash
+git-shadow uninstall
+```
+
+This:
+- Removes the git-shadow hooks from the effective hooks directory (respecting `core.hooksPath`) and restores any `<hook>.pre-shadow` backups made at install time
+- Removes this worktree's entries from the managed section of `.git/info/exclude` (entries owned by other worktrees are preserved)
+- Deletes this worktree's shadow state (`.git/shadow/`)
+
+For safety, `uninstall` **refuses** to run in two situations:
+- **Files are still managed** — it stops with an error listing the count. Either `git-shadow remove <file>` each file first, or re-run with `--force`.
+- **A commit is in progress** — a leftover stash or a lock held by another live process means a commit cycle is mid-flight, so wiping state could lose work.
+
+```bash
+# Restore overlay baselines to the working tree and wipe state even if files are still managed
+git-shadow uninstall --force
+```
+
+With `--force`, overlay files are restored to their baseline content (shadow changes discarded) and the count is reported, e.g. `restored baselines to the working tree for 1 overlay(s)`. Phantom files are left on disk untouched — they are your local-only files. On success you'll see `git-shadow uninstalled (hooks, exclude entries, and state removed)`.
+
+### Manual removal
+
+If the binary is unavailable and you need to remove git-shadow by hand:
+
+1. In the effective hooks directory (`.git/hooks/`, or your `core.hooksPath`), delete the `pre-commit`, `post-commit`, `post-merge`, and `post-rewrite` scripts that call `git-shadow hook`. If a `<hook>.pre-shadow` backup exists, rename it back to `<hook>`.
+2. Restore any overlay files you want to reset to their committed content (e.g., `git restore --source=HEAD -- <file>`).
+3. Delete `.git/shadow/`.
+4. Remove the git-shadow managed section (between its marker comments) from `.git/info/exclude`.
+
 ## Viewing Status and Changes
 
 ### Status
@@ -116,6 +166,33 @@ git shadow status --git
 
 This prints `git status --short --branch` first, then the shadow-managed summary. `git-shadow` does not replace `git status` by default.
 
+For scripting, use `--json`:
+
+```bash
+git-shadow status --json
+```
+
+This emits a stable, English (non-localized) JSON document and suppresses the human-readable output. Keys are stable identifiers suitable for parsing — for example `git_state` is one of `clean`, `modified`, `staged`, or `partially_staged`, and `warnings` holds tokens such as `stash_remaining` or `stale_lock`:
+
+```json
+{
+  "suspended": false,
+  "warnings": [],
+  "files": [
+    {
+      "path": "docker-compose.yml",
+      "type": "overlay",
+      "exists": true,
+      "baseline_commit": "f5fb751...",
+      "shadow_added": 1,
+      "shadow_removed": 0,
+      "git_state": "modified",
+      "baseline_outdated": false
+    }
+  ]
+}
+```
+
 ### Diff
 
 ```bash
@@ -131,15 +208,19 @@ git-shadow diff docker-compose.yml
 
 ## Handling Upstream Changes
 
-When the team updates a file you have an overlay on (e.g., after `git pull`):
+When the team updates a file you have an overlay on (e.g., after `git pull`), the `post-merge` and `post-rewrite` hooks run automatically:
+
+- **Clean merges** — the baseline and your shadow changes are re-applied automatically (a clean-only auto-rebase). No action is needed.
+- **Conflicts** — the auto-rebase is skipped and you are warned to resolve it manually with `git-shadow rebase <file>`.
+
+If a rebase is left to you, run it explicitly:
 
 ```bash
-# post-merge hook will warn you:
-# "warning: baseline for docker-compose.yml is outdated. Run `git-shadow rebase docker-compose.yml`"
-
 # Update your baseline and re-apply shadow changes
 git-shadow rebase docker-compose.yml
 ```
+
+If the lock is held by a live process when the hook fires, the auto-rebase is skipped for safety and you can run `git-shadow rebase` yourself afterward.
 
 The rebase performs a 3-way merge:
 1. Old baseline (common ancestor)
@@ -236,6 +317,19 @@ git-shadow restore docker-compose.yml
 
 When a stale lock is found during `git commit`, git-shadow also tries safe auto-recovery first. If restoring would overwrite newer working-tree content, the commit is still blocked and manual `git-shadow restore` is required.
 
+`restore` refuses to run when the lock is held by another **live** process (a real commit or hook is in flight), so it never clobbers work another process is doing. It only cleans up locks whose owning process is gone (stale).
+
+### Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Shadow changes get committed / hooks never run | `core.hooksPath` points somewhere other than where the hooks live, so they are inert | Re-run `git-shadow install` (it installs into the effective hooks directory). `git-shadow doctor` reports this as an issue. |
+| `git commit` blocked with "another git-shadow process still holds the lock" | Another live commit or hook is running | Wait for it to finish. If nothing is actually running, the lock is stale — run `git-shadow restore`. |
+| `git commit` blocked with "leftover files remain in `.git/shadow/stash/`" | A previous commit was interrupted | Run `git-shadow restore`, then commit again. |
+| `git-shadow restore` refuses to run | The lock is held by a live process | Let that process finish; restore only cleans up stale locks. |
+| `git-shadow resume` blocked with "was edited in the working tree while suspended" | You edited a file after suspending it, so resuming would overwrite your edits | Review the file, save what you want to keep, reconcile with `.git/shadow/suspended/`, then run `git-shadow resume` again. |
+| `git-shadow doctor` exits non-zero | It found one or more issues (broken hooks, missing baselines, inert hooks, ...) | Read the `issues:` list and address each; warnings alone do not cause a non-zero exit. |
+
 ## Diagnostics
 
 ```bash
@@ -243,10 +337,31 @@ git-shadow doctor
 ```
 
 Checks:
-- Hook files exist with correct permissions and content
+- Hook files exist with correct permissions and content, and are not inert (installed in the default directory while `core.hooksPath` points elsewhere)
 - No competing hook managers (Husky, pre-commit, lefthook)
 - Config integrity (managed files and baselines exist)
 - No stash remnants or stale locks
+- Suspended state and worktree initialization
+
+Findings are split into **issues** (red `✗`, things that are broken) and **warnings** (yellow `⚠`, things that need attention).
+
+**Exit codes:** `doctor` exits non-zero when it finds one or more issues (e.g., `Error: doctor found 4 issue(s)`), so you can gate scripts or CI on it. Warnings alone keep a zero exit code.
+
+For scripting, use `--json`:
+
+```bash
+git-shadow doctor --json
+```
+
+This emits a stable, English (non-localized) JSON document and suppresses the human-readable output. The `ok` field is `false` when there are issues (matching the non-zero exit code):
+
+```json
+{
+  "ok": true,
+  "issues": [],
+  "warnings": []
+}
+```
 
 ## Data Storage
 
@@ -357,6 +472,7 @@ With worktrees, suspend/resume is unnecessary — each worktree has independent 
 | Remove a worktree | `git worktree remove <path>` (shadow state cleaned up) |
 | Check status | `git-shadow status` / `git-shadow doctor` |
 | Branch switch (no worktree) | `git-shadow suspend` → checkout → `git-shadow resume` |
+| Remove git-shadow from a repo | `git-shadow uninstall` (or `--force`) |
 
 ## Important Notes
 

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -9,12 +9,13 @@ Root source directory. Modules are split by responsibility into focused, small f
 | `error.rs` | All error types via `thiserror` | `ShadowError` enum |
 | `config.rs` | JSON config load/save, file registry | `ShadowConfig`, `FileEntry`, `FileType`, `ExcludeMode` |
 | `path.rs` | Path normalization + URL encoding for flat storage | `normalize_path()`, `encode_path()`, `decode_path()` |
-| `lock.rs` | PID-based lockfile for concurrency safety | `LockStatus`, `acquire_lock()`, `release_lock()` |
+| `lock.rs` | PID-based lockfile for concurrency safety | `LockStatus` (`Free`/`HeldByOther`/`Stale`/`Corrupt`), `acquire_lock()`, `release_lock()`, `check_lock()` |
 | `fs_util.rs` | Atomic writes, binary detection, size checks | `atomic_write()`, `is_binary()`, `check_size()` |
-| `git.rs` | Worktree-aware Git CLI wrapper (no git2 crate) | `GitRepo` (root, git_dir, common_dir, shadow_dir; `hooks_dir()`) |
+| `git.rs` | Worktree-aware Git CLI wrapper (no git2 crate) | `GitRepo` (root, git_dir, common_dir, shadow_dir; `hooks_dir()`, `effective_hooks_dir()`) |
 | `exclude.rs` | `.git/info/exclude` section management | `ExcludeManager` |
 | `diff_util.rs` | Unified diff formatting with colors | `unified_diff()`, `print_colored_diff()` |
 | `merge.rs` | 3-way merge via `git merge-file -p --diff3` | `three_way_merge()`, `MergeResult` |
+| `ui.rs` | Locale (ja/en) detection + user-facing message/error formatting | `UiLocale`, `detect_locale()`, `format_error()` |
 | `cli.rs` | clap derive definitions | `Cli`, `Commands` enum |
 | `main.rs` | Entry point, dispatches to commands | - |
 | `lib.rs` | Re-exports all modules for integration tests | - |
@@ -42,7 +43,7 @@ Two error libraries are used intentionally:
 - **git_dir** -- per-worktree Git directory (`--git-dir`, e.g., `.git/worktrees/<name>`)
 - **common_dir** -- shared Git directory (`--git-common-dir`, e.g., `.git/`)
 
-`shadow_dir` is derived from `git_dir` (per-worktree state). `hooks_dir()` returns `common_dir.join("hooks")` so hooks are shared across worktrees. A `discover_fallback()` handles Git versions < 2.31 that lack `--git-common-dir`.
+`shadow_dir` is derived from `git_dir` (per-worktree state). `hooks_dir()` returns `common_dir.join("hooks")` so hooks are shared across worktrees; `effective_hooks_dir()` honors `core.hooksPath` when it is set (resolving a relative value against `root`) and otherwise falls back to `hooks_dir()` -- install/uninstall/doctor use the effective dir so hooks land where git actually runs them. A `discover_fallback()` handles Git versions < 2.31 that lack `--git-common-dir`.
 
 ### Atomic Writes
 
@@ -58,7 +59,7 @@ Decoding reverses the order. This guarantees `decode(encode(p)) == p` for any pa
 
 ### Lock Protocol
 
-`lock.rs` uses a PID + timestamp file. Stale detection uses `libc::kill(pid, 0)` (signal 0 = existence check without sending a signal). The lock is acquired by pre-commit and released by post-commit. If post-commit never runs (e.g., `--no-verify`), the lock becomes stale and `restore` cleans it up.
+`lock.rs` uses a PID + timestamp file, written atomically with `O_CREAT | O_EXCL` so concurrent acquirers cannot both win. Stale detection uses `libc::kill(pid, 0)` (signal 0 = existence check without sending a signal). `check_lock()` reports `Free`, `HeldByOther`, `Stale` (dead PID), or `Corrupt` (unparseable) without erroring, so callers can decide; `acquire_lock()` treats a corrupt lock like a stale one but does not silently clobber a live one. The lock is acquired by pre-commit and released by post-commit. If post-commit never runs (e.g., `--no-verify`), the lock becomes stale and `restore` cleans it up.
 
 ### ExcludeManager
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5,6 +5,7 @@ use crate::ui::UiLocale;
 #[derive(Parser)]
 #[command(
     name = "git-shadow",
+    version,
     about = "Manage local-only changes in Git repositories"
 )]
 pub struct Cli {
@@ -16,6 +17,13 @@ pub struct Cli {
 pub enum Commands {
     /// Set up Git hooks
     Install,
+
+    /// Remove git-shadow hooks, exclude entries, and state
+    Uninstall {
+        /// Restore overlay baselines and wipe state even if files are still managed
+        #[arg(long)]
+        force: bool,
+    },
 
     /// Register a file for shadow management
     Add {
@@ -49,6 +57,9 @@ pub enum Commands {
         /// Show `git status --short --branch` before the shadow summary
         #[arg(long)]
         git: bool,
+        /// Emit machine-readable JSON (English, not localized)
+        #[arg(long)]
+        json: bool,
     },
 
     /// Show shadow changes as a diff
@@ -76,7 +87,11 @@ pub enum Commands {
     Resume,
 
     /// Diagnose hooks and configuration
-    Doctor,
+    Doctor {
+        /// Emit machine-readable JSON (English, not localized)
+        #[arg(long)]
+        json: bool,
+    },
 
     /// Internal subcommand called from hooks
     #[command(hide = true)]
@@ -113,6 +128,20 @@ fn localize_subcommands(command: clap::Command, locale: UiLocale) -> clap::Comma
         sub.about(match locale {
             UiLocale::Ja => "Git hooks を設定する",
             UiLocale::En => "Set up Git hooks",
+        })
+    });
+    let command = command.mut_subcommand("uninstall", |sub| {
+        sub.about(match locale {
+            UiLocale::Ja => "git-shadow の hooks・exclude・state を削除する",
+            UiLocale::En => "Remove git-shadow hooks, exclude entries, and state",
+        })
+        .mut_arg("force", |arg| {
+            arg.help(match locale {
+                UiLocale::Ja => "管理対象が残っていても overlay を復元して state を削除する",
+                UiLocale::En => {
+                    "Restore overlay baselines and wipe state even if files are still managed"
+                }
+            })
         })
     });
     let command = command.mut_subcommand("add", |sub| {
@@ -180,6 +209,12 @@ fn localize_subcommands(command: clap::Command, locale: UiLocale) -> clap::Comma
                 UiLocale::En => "Also show `git status --short --branch` first",
             })
         })
+        .mut_arg("json", |arg| {
+            arg.help(match locale {
+                UiLocale::Ja => "機械可読な JSON を出力する (英語・非ローカライズ)",
+                UiLocale::En => "Emit machine-readable JSON (English, not localized)",
+            })
+        })
     });
     let command = command.mut_subcommand("diff", |sub| {
         sub.about(match locale {
@@ -233,6 +268,12 @@ fn localize_subcommands(command: clap::Command, locale: UiLocale) -> clap::Comma
         sub.about(match locale {
             UiLocale::Ja => "hooks と設定を診断する",
             UiLocale::En => "Diagnose hooks and configuration",
+        })
+        .mut_arg("json", |arg| {
+            arg.help(match locale {
+                UiLocale::Ja => "機械可読な JSON を出力する (英語・非ローカライズ)",
+                UiLocale::En => "Emit machine-readable JSON (English, not localized)",
+            })
         })
     })
 }

--- a/src/commands/CLAUDE.md
+++ b/src/commands/CLAUDE.md
@@ -7,15 +7,16 @@ User-facing CLI commands. Each file corresponds to one subcommand and exposes a 
 | Command | File | Description |
 |---------|------|-------------|
 | `git-shadow install` | `install.rs` | Creates `.git/shadow/` dirs and installs hook scripts |
+| `git-shadow uninstall` | `uninstall.rs` | Removes shadow hooks and per-worktree state (refuses with active entries unless `--force`) |
 | `git-shadow add <file>` | `add.rs` | Registers overlay or phantom (with `--phantom`) |
 | `git-shadow remove <file>` | `remove.rs` | Unregisters with confirmation prompt |
-| `git-shadow status` | `status.rs` | Shows managed files, diff stats, warnings |
+| `git-shadow status` | `status.rs` | Shows managed files, diff stats, warnings (`--json`) |
 | `git-shadow diff [file]` | `diff.rs` | Shows shadow changes as unified diff |
 | `git-shadow rebase [file]` | `rebase.rs` | Updates baseline via 3-way merge |
 | `git-shadow restore [file]` | `restore.rs` | Recovers from interrupted commits |
 | `git-shadow suspend` | `suspend.rs` | Suspends shadow changes for branch switching |
 | `git-shadow resume` | `resume.rs` | Resumes suspended shadow changes (with 3-way merge) |
-| `git-shadow doctor` | `doctor.rs` | Diagnoses hooks, config, stale state |
+| `git-shadow doctor` | `doctor.rs` | Diagnoses hooks, config, stale state (`--json`, non-zero exit on issues) |
 | `git-shadow hook <name>` | `hook.rs` | Internal dispatcher called from hook scripts |
 
 ## Design Notes
@@ -30,7 +31,11 @@ Every command follows the same structure:
 
 ### install.rs: Hook Chaining
 
-Generated hook scripts call `git-shadow hook <name>` first, then chain to any pre-existing hook (renamed to `<hook>.pre-shadow`). This preserves existing hooks from other tools. Idempotent -- re-running `install` skips already-installed hooks. Hooks are installed to `common_dir/hooks/` so they are shared across worktrees. In a worktree, `inherit_from_main_worktree()` auto-inherits the managed file list from the main repo if no local config exists yet -- overlay baselines are regenerated from the worktree's HEAD, phantom entries are copied as-is.
+Generated hook scripts call `git-shadow hook <name>` first, then chain to any pre-existing hook (renamed to `<hook>.pre-shadow`). This preserves existing hooks from other tools. Idempotent -- re-running `install` skips already-installed hooks. Four hooks are installed (`pre-commit`, `post-commit`, `post-merge`, `post-rewrite`) into `git.effective_hooks_dir()`: it honors `core.hooksPath` when set (so hooks actually run under husky/lefthook/custom setups), otherwise `common_dir/hooks/` so they are shared across worktrees. In a worktree, `inherit_from_main_worktree()` auto-inherits the managed file list from the main repo if no local config exists yet -- overlay baselines are regenerated from the worktree's HEAD, phantom entries are copied as-is.
+
+### uninstall.rs: Reverse of install
+
+Refuses while a commit is mid-flight (stash remnant or live lock) and refuses if files are still managed (`UninstallHasEntries`) unless `--force` -- which first restores overlay baselines to the working tree (phantoms are left on disk). Removes the shadow hooks from `effective_hooks_dir()` (only those dispatching to `git-shadow hook`), restores any `<hook>.pre-shadow` backup, regenerates the shared exclude section from the *other* worktrees' configs, then deletes this worktree's `shadow_dir`.
 
 ### add.rs: Overlay vs Phantom Validation
 
@@ -64,4 +69,4 @@ The `hook` subcommand is `#[command(hide = true)]` in clap -- it doesn't appear 
 
 ### doctor.rs: Diagnostic Categories
 
-Checks are split into **issues** (red, things that are broken) and **warnings** (yellow, things that need attention). Checks include: hook existence/permissions/content, competing hook managers (Husky, pre-commit, lefthook), config integrity, stash remnants, stale locks, suspended state, and worktree initialization (`check_worktree()` warns if running in a worktree where `git-shadow install` has not been run yet).
+Checks are split into **issues** (red, things that are broken) and **warnings** (yellow, things that need attention). Any issue makes `doctor` exit non-zero (so scripts/CI can gate on it); warnings alone keep a zero exit. `--json` emits a structured, English-only report. Checks include: hook existence/permissions/content, inert hooks (installed in the default dir while `core.hooksPath` points elsewhere), competing hook managers (Husky, pre-commit, lefthook), config integrity, stash remnants, stale locks, suspended state, and worktree initialization (`check_worktree()` warns if running in a worktree where `git-shadow install` has not been run yet).

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -133,6 +133,12 @@ fn add_overlay(
 
     fs_util::check_size(&file_path, force)?;
 
+    // Reject duplicates BEFORE writing the baseline, so a failed re-add cannot overwrite
+    // the stored baseline (which would leave baseline_commit inconsistent with its content).
+    if config.get(normalized).is_some() {
+        return Err(ShadowError::AlreadyManaged(normalized.to_string()).into());
+    }
+
     let commit = git.head_commit()?;
     let baseline_content = git.show_file("HEAD", normalized)?;
 
@@ -142,19 +148,13 @@ fn add_overlay(
 
     config.add_overlay(normalized.to_string(), commit)?;
 
-    println!(
-        "{}",
-        ui::registered_overlay(
-            locale,
-            normalized,
-            &config
-                .get(normalized)
-                .unwrap()
-                .baseline_commit
-                .as_deref()
-                .unwrap_or("?")[..7],
-        )
-    );
+    let baseline_commit = config
+        .get(normalized)
+        .and_then(|e| e.baseline_commit.as_deref())
+        .unwrap_or("?");
+    let short = &baseline_commit[..7.min(baseline_commit.len())];
+
+    println!("{}", ui::registered_overlay(locale, normalized, short));
     Ok(())
 }
 
@@ -174,19 +174,22 @@ fn add_phantom(
     let exclude_mode = if no_exclude {
         ExcludeMode::None
     } else {
-        let exclude_path = if is_dir {
-            format!("{}/", normalized)
-        } else {
-            normalized.to_string()
-        };
-        let manager = ExcludeManager::new(&git.common_dir);
-        manager
-            .add_entry(&exclude_path)
-            .context("failed to add to .git/info/exclude")?;
         ExcludeMode::GitInfoExclude
     };
 
-    config.add_phantom(normalized.to_string(), exclude_mode, is_dir)?;
+    // Register in config first so the duplicate check runs before we touch the shared
+    // exclude file.
+    config.add_phantom(normalized.to_string(), exclude_mode.clone(), is_dir)?;
+
+    if exclude_mode == ExcludeMode::GitInfoExclude {
+        // Regenerate the managed section from the union of all worktrees' configs. This
+        // writes anchored/escaped patterns and upgrades any stale unanchored entries.
+        let manager = ExcludeManager::new(&git.common_dir);
+        let patterns = crate::exclude::union_patterns(git, config);
+        manager
+            .set_entries(&patterns)
+            .context("failed to update .git/info/exclude")?;
+    }
 
     if is_dir {
         println!(
@@ -330,6 +333,29 @@ mod tests {
     }
 
     #[test]
+    fn test_add_overlay_duplicate_does_not_overwrite_baseline() {
+        let (_dir, git) = make_test_repo();
+        let mut config = ShadowConfig::new();
+        add_overlay(&git, &mut config, "CLAUDE.md", false).unwrap();
+
+        let encoded = path::encode_path("CLAUDE.md");
+        let baseline_path = git.shadow_dir.join("baselines").join(&encoded);
+
+        // Tamper with the stored baseline to a sentinel value.
+        std::fs::write(&baseline_path, b"SENTINEL BASELINE\n").unwrap();
+
+        // Re-adding the same file must fail without touching the baseline file.
+        let result = add_overlay(&git, &mut config, "CLAUDE.md", false);
+        assert!(result.is_err());
+
+        let content = std::fs::read_to_string(&baseline_path).unwrap();
+        assert_eq!(
+            content, "SENTINEL BASELINE\n",
+            "baseline must not be rewritten by a failed duplicate add"
+        );
+    }
+
+    #[test]
     fn test_add_phantom_creates_config_entry() {
         let (_dir, git) = make_test_repo();
         let phantom_dir = git.root.join("src").join("components");
@@ -356,7 +382,62 @@ mod tests {
 
         let manager = ExcludeManager::new(&git.common_dir);
         let entries = manager.list_entries().unwrap();
-        assert!(entries.contains(&"src/CLAUDE.md".to_string()));
+        assert!(
+            entries.contains(&"/src/CLAUDE.md".to_string()),
+            "pattern should be anchored, got: {:?}",
+            entries
+        );
+    }
+
+    #[test]
+    fn test_add_phantom_exclude_pattern_is_anchored_and_escaped() {
+        let (_dir, git) = make_test_repo();
+        // File name containing gitignore metacharacters.
+        std::fs::write(git.root.join("a[b]*.md"), "# Local\n").unwrap();
+
+        let mut config = ShadowConfig::new();
+        add_phantom(&git, &mut config, "a[b]*.md", false).unwrap();
+
+        let manager = ExcludeManager::new(&git.common_dir);
+        let entries = manager.list_entries().unwrap();
+        assert!(
+            entries.contains(&"/a\\[b\\]\\*.md".to_string()),
+            "pattern should be anchored and escaped, got: {:?}",
+            entries
+        );
+    }
+
+    #[test]
+    fn test_add_phantom_upgrades_unanchored_exclude_entry() {
+        let (_dir, git) = make_test_repo();
+        std::fs::write(git.root.join("local.md"), "# Local\n").unwrap();
+        std::fs::write(git.root.join("other.md"), "# Other\n").unwrap();
+
+        // Simulate a stale unanchored entry left by an older version, plus a config
+        // entry describing that phantom.
+        let manager = ExcludeManager::new(&git.common_dir);
+        manager.add_entry("local.md").unwrap();
+
+        let mut config = ShadowConfig::new();
+        config
+            .add_phantom("local.md".to_string(), ExcludeMode::GitInfoExclude, false)
+            .unwrap();
+
+        // Adding another phantom rewrites the section from config.
+        add_phantom(&git, &mut config, "other.md", false).unwrap();
+
+        let entries = manager.list_entries().unwrap();
+        assert!(
+            entries.contains(&"/local.md".to_string()),
+            "stale unanchored entry should be upgraded, got: {:?}",
+            entries
+        );
+        assert!(
+            !entries.contains(&"local.md".to_string()),
+            "unanchored entry should be gone, got: {:?}",
+            entries
+        );
+        assert!(entries.contains(&"/other.md".to_string()));
     }
 
     #[test]
@@ -398,7 +479,11 @@ mod tests {
 
         let manager = ExcludeManager::new(&git.common_dir);
         let entries = manager.list_entries().unwrap();
-        assert!(entries.contains(&".claude/".to_string()));
+        assert!(
+            entries.contains(&"/.claude/".to_string()),
+            "directory pattern should be anchored with trailing slash, got: {:?}",
+            entries
+        );
     }
 
     #[test]

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -1,46 +1,59 @@
 use anyhow::Result;
 use colored::Colorize;
+use serde::Serialize;
 
 use crate::config::{FileType, ShadowConfig};
+use crate::error::ShadowError;
 use crate::git::GitRepo;
 use crate::lock::{self, LockStatus};
 use crate::path;
-use crate::ui;
+use crate::ui::{self, UiLocale};
 
 const HOOK_NAMES: &[&str] = &["pre-commit", "post-commit", "post-merge", "post-rewrite"];
 const COMPETING_HOOKS: &[&str] = &[".husky", ".pre-commit-config.yaml", "lefthook.yml"];
 
-pub fn run() -> Result<()> {
+/// Machine-readable doctor report (stable English keys/values, not localized).
+#[derive(Serialize)]
+struct DoctorReport<'a> {
+    ok: bool,
+    issues: &'a [String],
+    warnings: &'a [String],
+}
+
+/// Run all diagnostic checks and collect issues (broken) and warnings (attention).
+fn collect(git: &GitRepo, config: &ShadowConfig, locale: UiLocale) -> (Vec<String>, Vec<String>) {
+    let mut issues = Vec::new();
+    let mut warnings = Vec::new();
+
+    check_hooks(git, &mut issues, &mut warnings, locale);
+    check_competing_hooks(git, &mut warnings, locale);
+    check_config_integrity(git, config, &mut issues, locale);
+    check_stash(git, &mut warnings, locale);
+    check_lock(git, &mut warnings, locale);
+    check_suspended(config, git, &mut warnings, locale);
+    check_worktree(git, &mut warnings, locale);
+
+    (issues, warnings)
+}
+
+pub fn run(json: bool) -> Result<()> {
     let locale = ui::detect_locale();
     let git = GitRepo::discover(&std::env::current_dir()?)?;
     let config = ShadowConfig::load(&git.shadow_dir)?;
 
-    let mut issues = Vec::new();
-    let mut warnings = Vec::new();
+    // JSON output must be stable and English regardless of locale.
+    let report_locale = if json { UiLocale::En } else { locale };
+    let (issues, warnings) = collect(&git, &config, report_locale);
+    let issue_count = issues.len();
 
-    // 1. Check hook files
-    check_hooks(&git, &mut issues, &mut warnings, locale);
-
-    // 2. Check competing hook managers
-    check_competing_hooks(&git, &mut warnings, locale);
-
-    // 3. Check config integrity
-    check_config_integrity(&git, &config, &mut issues, locale);
-
-    // 4. Check stash remnants
-    check_stash(&git, &mut warnings, locale);
-
-    // 5. Check lock
-    check_lock(&git, &mut warnings, locale);
-
-    // 6. Check suspended state
-    check_suspended(&config, &git, &mut warnings, locale);
-
-    // 7. Check worktree environment
-    check_worktree(&git, &mut warnings, locale);
-
-    // Print results
-    if issues.is_empty() && warnings.is_empty() {
+    if json {
+        let report = DoctorReport {
+            ok: issues.is_empty(),
+            issues: &issues,
+            warnings: &warnings,
+        };
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else if issues.is_empty() && warnings.is_empty() {
         println!("{}", ui::doctor_all_checks_passed(locale).green());
     } else {
         if !issues.is_empty() {
@@ -57,6 +70,12 @@ pub fn run() -> Result<()> {
         }
     }
 
+    // Issues (red) make doctor exit non-zero so scripts/CI can gate on it.
+    // Warnings alone keep a zero exit code. The full report is printed first.
+    if issue_count > 0 {
+        return Err(ShadowError::DoctorFoundIssues(issue_count).into());
+    }
+
     Ok(())
 }
 
@@ -66,8 +85,28 @@ fn check_hooks(
     warnings: &mut Vec<String>,
     locale: ui::UiLocale,
 ) {
+    let effective_dir = git.effective_hooks_dir();
+
+    // Detect inert hooks: installed in the default dir, but core.hooksPath points
+    // elsewhere so Git never runs them (silent data-leak risk).
+    if let Some(hooks_path) = git.hooks_path_config() {
+        let default_dir = git.hooks_dir();
+        if default_dir != effective_dir {
+            let default_installed = HOOK_NAMES
+                .iter()
+                .all(|name| hook_calls_shadow(&default_dir.join(name)));
+            let effective_installed = HOOK_NAMES
+                .iter()
+                .all(|name| hook_calls_shadow(&effective_dir.join(name)));
+            if default_installed && !effective_installed {
+                issues.push(ui::doctor_hooks_inert(locale, &hooks_path));
+                return;
+            }
+        }
+    }
+
     for hook_name in HOOK_NAMES {
-        let hook_path = git.hooks_dir().join(hook_name);
+        let hook_path = effective_dir.join(hook_name);
 
         if !hook_path.exists() {
             issues.push(ui::doctor_hook_missing(locale, hook_name));
@@ -92,6 +131,13 @@ fn check_hooks(
             }
         }
     }
+}
+
+/// Whether the hook file at `path` exists and dispatches to git-shadow.
+fn hook_calls_shadow(path: &std::path::Path) -> bool {
+    std::fs::read_to_string(path)
+        .map(|content| content.contains("git-shadow hook") || content.contains("git shadow hook"))
+        .unwrap_or(false)
 }
 
 fn check_competing_hooks(git: &GitRepo, warnings: &mut Vec<String>, locale: ui::UiLocale) {
@@ -423,6 +469,66 @@ mod tests {
             "Should have no issues when directory exists, got: {:?}",
             issues
         );
+    }
+
+    fn install_default_hooks(git: &GitRepo) {
+        let hooks_dir = git.hooks_dir();
+        std::fs::create_dir_all(&hooks_dir).unwrap();
+        for name in super::HOOK_NAMES {
+            let content = format!("#!/bin/sh\ngit-shadow hook {}\n", name);
+            std::fs::write(hooks_dir.join(name), &content).unwrap();
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                std::fs::set_permissions(
+                    hooks_dir.join(name),
+                    std::fs::Permissions::from_mode(0o755),
+                )
+                .unwrap();
+            }
+        }
+    }
+
+    #[test]
+    fn test_inert_hooks_detected_when_hooks_path_set() {
+        let (_dir, git) = make_test_repo();
+        // Hooks installed in the default dir...
+        install_default_hooks(&git);
+        // ...but core.hooksPath points elsewhere, so they never run.
+        std::process::Command::new("git")
+            .args(["config", "core.hooksPath", "dev-hooks"])
+            .current_dir(&git.root)
+            .output()
+            .unwrap();
+
+        let mut issues = Vec::new();
+        let mut warnings = Vec::new();
+        super::check_hooks(&git, &mut issues, &mut warnings, UiLocale::En);
+
+        assert!(
+            issues.iter().any(|i| i.contains("core.hooksPath")),
+            "should report inert hooks, got: {:?}",
+            issues
+        );
+    }
+
+    #[test]
+    fn test_collect_reports_issues_when_hooks_missing() {
+        let (_dir, git) = make_test_repo();
+        let config = ShadowConfig::new();
+        let (issues, _warnings) = super::collect(&git, &config, UiLocale::En);
+        assert!(!issues.is_empty(), "missing hooks should surface as issues");
+    }
+
+    #[test]
+    fn test_collect_no_issues_when_healthy() {
+        let (_dir, git) = make_test_repo();
+        let config = ShadowConfig::new();
+        config.save(&git.shadow_dir).unwrap();
+        install_default_hooks(&git);
+
+        let (issues, _warnings) = super::collect(&git, &config, UiLocale::En);
+        assert!(issues.is_empty(), "healthy repo should have no issues");
     }
 
     #[test]

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -13,7 +13,7 @@ fn generate_hook_script(hook_name: &str) -> String {
     format!(
         r#"#!/bin/sh
 # git-shadow managed hook
-HOOKS_DIR="$(cd "$(git rev-parse --git-common-dir)" && pwd)/hooks"
+HOOKS_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 git-shadow hook {hook_name}
 SHADOW_EXIT=$?
@@ -44,7 +44,10 @@ pub fn run() -> Result<()> {
     // In a worktree, inherit config from main repo if available
     inherit_from_main_worktree(&git)?;
 
-    let hooks_dir = git.hooks_dir();
+    // Honor core.hooksPath: if set (husky, lefthook, dev-hooks, ...), hooks in the
+    // default common_dir/hooks would never run, so install into the effective directory.
+    let hooks_dir = git.effective_hooks_dir();
+    let custom_hooks_path = git.hooks_path_config();
     std::fs::create_dir_all(&hooks_dir).context("failed to create hooks directory")?;
 
     for hook_name in HOOK_NAMES {
@@ -71,6 +74,13 @@ pub fn run() -> Result<()> {
         let mut perms = std::fs::metadata(&hook_path)?.permissions();
         perms.set_mode(0o755);
         std::fs::set_permissions(&hook_path, perms)?;
+    }
+
+    if let Some(hooks_path) = custom_hooks_path {
+        println!(
+            "{}",
+            ui::install_custom_hooks_path(locale, &hooks_path, &hooks_dir.display().to_string())
+        );
     }
 
     println!("{}", ui::install_success(locale));
@@ -185,7 +195,7 @@ mod tests {
         std::fs::create_dir_all(shadow_dir.join("baselines")).unwrap();
         std::fs::create_dir_all(shadow_dir.join("stash")).unwrap();
 
-        let hooks_dir = git.hooks_dir();
+        let hooks_dir = git.effective_hooks_dir();
         std::fs::create_dir_all(&hooks_dir).unwrap();
 
         for hook_name in HOOK_NAMES {
@@ -270,6 +280,40 @@ mod tests {
     }
 
     #[test]
+    fn test_install_respects_hooks_path() {
+        let (_dir, git) = make_test_repo();
+
+        // Simulate husky/lefthook/dev-hooks: core.hooksPath points elsewhere.
+        std::process::Command::new("git")
+            .args(["config", "core.hooksPath", "dev-hooks"])
+            .current_dir(&git.root)
+            .output()
+            .unwrap();
+
+        install_hooks(&git);
+
+        // Hooks must land in the custom directory, not common_dir/hooks.
+        let custom_dir = git.root.join("dev-hooks");
+        for name in HOOK_NAMES {
+            let hook = custom_dir.join(name);
+            assert!(hook.exists(), "{} should exist in custom hooks dir", name);
+            let content = std::fs::read_to_string(&hook).unwrap();
+            assert!(content.contains(&format!("git-shadow hook {}", name)));
+        }
+
+        // Nothing should have been written to the default hooks dir.
+        for name in HOOK_NAMES {
+            assert!(
+                !git.hooks_dir().join(name).exists(),
+                "{} should NOT exist in default hooks dir",
+                name
+            );
+        }
+
+        assert!(git.hooks_installed());
+    }
+
+    #[test]
     fn test_creates_shadow_directories() {
         let (_dir, git) = make_test_repo();
         install_hooks(&git);
@@ -308,7 +352,7 @@ mod tests {
 
         super::inherit_from_main_worktree(git).unwrap();
 
-        let hooks_dir = git.hooks_dir();
+        let hooks_dir = git.effective_hooks_dir();
         std::fs::create_dir_all(&hooks_dir).unwrap();
 
         for hook_name in HOOK_NAMES {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -9,3 +9,4 @@ pub mod restore;
 pub mod resume;
 pub mod status;
 pub mod suspend;
+pub mod uninstall;

--- a/src/commands/rebase.rs
+++ b/src/commands/rebase.rs
@@ -5,6 +5,7 @@ use crate::config::{FileType, ShadowConfig};
 use crate::error::ShadowError;
 use crate::fs_util;
 use crate::git::GitRepo;
+use crate::lock;
 use crate::merge;
 use crate::path;
 use crate::ui;
@@ -178,11 +179,36 @@ pub(crate) fn rebase_file_with_mode(
 }
 
 pub fn auto_rebase_all(git: &GitRepo, trigger: &str) -> Result<()> {
-    let mut config = ShadowConfig::load(&git.shadow_dir)?;
+    let config = ShadowConfig::load(&git.shadow_dir)?;
     if config.suspended || config.files.is_empty() {
         return Ok(());
     }
 
+    // This runs from post-merge/post-rewrite hooks and mutates the working tree,
+    // baselines and config.json, so it must hold the shadow lock. If another
+    // git-shadow process holds it (e.g. a commit is in progress) or the lock is
+    // stale/corrupt, skip with a warning rather than failing the git operation.
+    let locale = ui::detect_locale();
+    match lock::acquire_lock(&git.shadow_dir) {
+        Ok(()) => {}
+        Err(
+            ShadowError::LockHeld { .. } | ShadowError::StaleLock(_) | ShadowError::CorruptLock,
+        ) => {
+            eprintln!(
+                "{}",
+                ui::auto_rebase_skipped_locked(locale, trigger).yellow()
+            );
+            return Ok(());
+        }
+        Err(e) => return Err(e.into()),
+    }
+
+    let result = auto_rebase_all_locked(git, config, trigger);
+    lock::release_lock(&git.shadow_dir).ok();
+    result
+}
+
+fn auto_rebase_all_locked(git: &GitRepo, mut config: ShadowConfig, trigger: &str) -> Result<()> {
     let head = git.head_commit()?;
     let file_paths: Vec<String> = config.files.keys().cloned().collect();
 
@@ -448,6 +474,108 @@ mod tests {
         // Verify working tree is unchanged (shadow changes preserved)
         let wt = std::fs::read_to_string(git.root.join("CLAUDE.md")).unwrap();
         assert_eq!(wt, "# Team\n# My shadow\n");
+    }
+
+    fn setup_outdated_overlay(git: &GitRepo) -> String {
+        // Overlay whose baseline is behind HEAD, so auto_rebase_all would act on
+        // it. Base and upstream edits touch different regions so the 3-way merge
+        // is clean (no conflict), letting auto-rebase update the baseline.
+        std::fs::write(git.root.join("CLAUDE.md"), "line1\nline2\nline3\n").unwrap();
+        std::process::Command::new("git")
+            .args(["add", "CLAUDE.md"])
+            .current_dir(&git.root)
+            .output()
+            .unwrap();
+        std::process::Command::new("git")
+            .args(["commit", "-m", "set base"])
+            .current_dir(&git.root)
+            .output()
+            .unwrap();
+        let old_commit = git.head_commit().unwrap();
+
+        let mut config = ShadowConfig::new();
+        let encoded = path::encode_path("CLAUDE.md");
+        fs_util::atomic_write(
+            &git.shadow_dir.join("baselines").join(&encoded),
+            b"line1\nline2\nline3\n",
+        )
+        .unwrap();
+        config
+            .add_overlay("CLAUDE.md".to_string(), old_commit)
+            .unwrap();
+        config.save(&git.shadow_dir).unwrap();
+
+        // Advance HEAD with an upstream change to the FIRST line.
+        std::fs::write(git.root.join("CLAUDE.md"), "line1 upstream\nline2\nline3\n").unwrap();
+        std::process::Command::new("git")
+            .args(["add", "CLAUDE.md"])
+            .current_dir(&git.root)
+            .output()
+            .unwrap();
+        std::process::Command::new("git")
+            .args(["commit", "-m", "upstream"])
+            .current_dir(&git.root)
+            .output()
+            .unwrap();
+
+        // Shadow change appends at the END (non-conflicting region).
+        std::fs::write(
+            git.root.join("CLAUDE.md"),
+            "line1\nline2\nline3\nmy shadow\n",
+        )
+        .unwrap();
+        git.head_commit().unwrap()
+    }
+
+    #[test]
+    fn test_auto_rebase_all_releases_lock_on_success() {
+        let (_dir, git) = make_test_repo();
+        setup_outdated_overlay(&git);
+
+        super::auto_rebase_all(&git, "post-merge").unwrap();
+
+        // Lock must be released after a successful auto-rebase.
+        assert!(matches!(
+            crate::lock::check_lock(&git.shadow_dir).unwrap(),
+            crate::lock::LockStatus::Free
+        ));
+        // Baseline was updated (proves it actually ran under the lock).
+        let encoded = path::encode_path("CLAUDE.md");
+        let baseline =
+            std::fs::read_to_string(git.shadow_dir.join("baselines").join(&encoded)).unwrap();
+        assert_eq!(baseline, "line1 upstream\nline2\nline3\n");
+    }
+
+    #[test]
+    fn test_auto_rebase_all_skips_when_lock_held_live() {
+        let (_dir, git) = make_test_repo();
+        setup_outdated_overlay(&git);
+        let encoded = path::encode_path("CLAUDE.md");
+
+        // Live lock held by a real, signalable child process.
+        let mut child = std::process::Command::new("sleep")
+            .arg("30")
+            .spawn()
+            .unwrap();
+        let lock_content = format!(
+            "pid={}\ntimestamp={}",
+            child.id(),
+            chrono::Utc::now().to_rfc3339()
+        );
+        std::fs::write(git.shadow_dir.join("lock"), &lock_content).unwrap();
+
+        let result = super::auto_rebase_all(&git, "post-merge");
+        let lock_after = std::fs::read_to_string(git.shadow_dir.join("lock")).unwrap();
+        let _ = child.kill();
+        let _ = child.wait();
+        result.unwrap();
+
+        // The foreign lock must be left untouched...
+        assert_eq!(lock_after, lock_content);
+        // ...and no rebase happened: baseline is still the old content.
+        let baseline =
+            std::fs::read_to_string(git.shadow_dir.join("baselines").join(&encoded)).unwrap();
+        assert_eq!(baseline, "line1\nline2\nline3\n");
     }
 
     /// Helper to rebase a file (bypasses cwd discovery)

--- a/src/commands/remove.rs
+++ b/src/commands/remove.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use colored::Colorize;
 use is_terminal::IsTerminal;
 
-use crate::config::{ExcludeMode, FileType, ShadowConfig};
+use crate::config::{FileType, ShadowConfig};
 use crate::error::ShadowError;
 use crate::exclude::ExcludeManager;
 use crate::git::GitRepo;
@@ -48,16 +48,20 @@ pub fn run(file: &str, force: bool) -> Result<()> {
         }
     }
 
-    match entry.file_type {
-        FileType::Overlay => {
-            remove_overlay(&git, &normalized)?;
-        }
-        FileType::Phantom => {
-            remove_phantom(&git, &normalized, &entry.exclude_mode, entry.is_directory)?;
-        }
+    if entry.file_type == FileType::Overlay {
+        remove_overlay(&git, &normalized)?;
     }
 
     config.remove(&normalized)?;
+
+    // Regenerate the shared exclude section from the union of all worktrees' configs.
+    // This keeps entries that other worktrees still rely on (config is per-worktree but
+    // .git/info/exclude is shared), and only drops the removed entry if no worktree needs
+    // it anymore.
+    let manager = ExcludeManager::new(&git.common_dir);
+    let patterns = crate::exclude::union_patterns(&git, &config);
+    manager.set_entries(&patterns)?;
+
     config.save(&git.shadow_dir)?;
 
     println!("{}", ui::unregistered(locale, &normalized).green());
@@ -75,26 +79,6 @@ fn remove_overlay(git: &GitRepo, file_path: &str) -> Result<()> {
         let baseline = std::fs::read(&baseline_path)?;
         std::fs::write(&worktree_path, &baseline)?;
         std::fs::remove_file(&baseline_path)?;
-    }
-
-    Ok(())
-}
-
-fn remove_phantom(
-    git: &GitRepo,
-    file_path: &str,
-    exclude_mode: &ExcludeMode,
-    is_directory: bool,
-) -> Result<()> {
-    // Remove from .git/info/exclude if applicable
-    if *exclude_mode == ExcludeMode::GitInfoExclude {
-        let exclude_path = if is_directory {
-            format!("{}/", file_path)
-        } else {
-            file_path.to_string()
-        };
-        let manager = ExcludeManager::new(&git.common_dir);
-        manager.remove_entry(&exclude_path)?;
     }
 
     Ok(())
@@ -384,5 +368,84 @@ mod tests {
 
         let entries = manager.list_entries().unwrap();
         assert!(!entries.contains(&"local.md".to_string()));
+    }
+
+    #[test]
+    fn test_remove_keeps_exclude_entry_used_by_another_worktree() {
+        use std::process::Command;
+
+        // Main repo with an installed shadow config.
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().to_path_buf();
+        Command::new("git")
+            .args(["init"])
+            .current_dir(&root)
+            .output()
+            .unwrap();
+        Command::new("git")
+            .args(["config", "user.name", "Test"])
+            .current_dir(&root)
+            .output()
+            .unwrap();
+        Command::new("git")
+            .args(["config", "user.email", "t@t.com"])
+            .current_dir(&root)
+            .output()
+            .unwrap();
+        std::fs::write(root.join("CLAUDE.md"), "# Team\n").unwrap();
+        Command::new("git")
+            .args(["add", "CLAUDE.md"])
+            .current_dir(&root)
+            .output()
+            .unwrap();
+        Command::new("git")
+            .args(["commit", "-m", "init"])
+            .current_dir(&root)
+            .output()
+            .unwrap();
+
+        let main_git = GitRepo::discover(&root).unwrap();
+        std::fs::create_dir_all(main_git.shadow_dir.join("baselines")).unwrap();
+        std::fs::create_dir_all(main_git.shadow_dir.join("stash")).unwrap();
+
+        // Both worktrees manage the same phantom `local.md`.
+        let mut main_config = ShadowConfig::new();
+        main_config
+            .add_phantom("local.md".to_string(), ExcludeMode::GitInfoExclude, false)
+            .unwrap();
+        main_config.save(&main_git.shadow_dir).unwrap();
+
+        // Create a worktree and give it its own config referencing the same phantom.
+        let wt_path = dir.path().join("worktree");
+        Command::new("git")
+            .args([
+                "worktree",
+                "add",
+                "-b",
+                "wt-branch",
+                wt_path.to_str().unwrap(),
+            ])
+            .current_dir(&root)
+            .output()
+            .unwrap();
+        let wt_git = GitRepo::discover(&wt_path).unwrap();
+        std::fs::create_dir_all(wt_git.shadow_dir.join("baselines")).unwrap();
+        std::fs::create_dir_all(wt_git.shadow_dir.join("stash")).unwrap();
+        let mut wt_config = ShadowConfig::new();
+        wt_config
+            .add_phantom("local.md".to_string(), ExcludeMode::GitInfoExclude, false)
+            .unwrap();
+        wt_config.save(&wt_git.shadow_dir).unwrap();
+
+        // Simulate removing `local.md` from the main worktree only.
+        main_config.remove("local.md").unwrap();
+        let patterns = crate::exclude::union_patterns(&main_git, &main_config);
+
+        // The worktree still references it, so the shared entry must remain.
+        assert!(
+            patterns.contains(&"/local.md".to_string()),
+            "shared exclude entry must be kept, got: {:?}",
+            patterns
+        );
     }
 }

--- a/src/commands/restore.rs
+++ b/src/commands/restore.rs
@@ -1,13 +1,32 @@
 use anyhow::Result;
 
+use crate::error::ShadowError;
 use crate::git::GitRepo;
-use crate::lock;
+use crate::lock::{self, LockStatus};
 use crate::path;
 use crate::ui;
 
 pub fn run(file: Option<&str>) -> Result<()> {
     let locale = ui::detect_locale();
     let git = GitRepo::discover(&std::env::current_dir()?)?;
+    run_with(&git, file, locale)
+}
+
+fn run_with(git: &GitRepo, file: Option<&str>, locale: ui::UiLocale) -> Result<()> {
+    // Refuse to touch anything while a live process holds the lock: a commit is
+    // in progress and restoring stash/removing the lock would corrupt it. A
+    // stale (dead PID) or corrupt lock is safe to reclaim.
+    match lock::check_lock(&git.shadow_dir)? {
+        LockStatus::HeldByOther(info) => {
+            return Err(ShadowError::LockHeld {
+                pid: info.pid,
+                timestamp: info.timestamp.to_rfc3339(),
+            }
+            .into());
+        }
+        LockStatus::Free | LockStatus::HeldByUs | LockStatus::Stale(_) | LockStatus::Corrupt => {}
+    }
+
     let stash_dir = git.shadow_dir.join("stash");
     let mut restored = Vec::new();
 
@@ -192,39 +211,55 @@ mod tests {
         assert_eq!(content, "# Component\n");
     }
 
+    #[test]
+    fn test_refuses_when_lock_held_by_live_process() {
+        let (_dir, git) = make_test_repo();
+
+        // Stash something so we can prove it is NOT restored while locked.
+        fs_util::atomic_write(
+            &git.shadow_dir.join("stash").join("CLAUDE.md"),
+            b"# Shadow content\n",
+        )
+        .unwrap();
+        std::fs::write(git.root.join("CLAUDE.md"), "# Team\n").unwrap();
+
+        // Live lock held by a real, signalable child process.
+        let mut child = std::process::Command::new("sleep")
+            .arg("30")
+            .spawn()
+            .unwrap();
+        std::fs::write(
+            git.shadow_dir.join("lock"),
+            format!(
+                "pid={}\ntimestamp={}",
+                child.id(),
+                chrono::Utc::now().to_rfc3339()
+            ),
+        )
+        .unwrap();
+
+        let result = run_with(&git, None, ui::UiLocale::En);
+        let _ = child.kill();
+        let _ = child.wait();
+
+        assert!(result.is_err(), "restore must refuse while lock is live");
+        let err = result.unwrap_err();
+        assert!(err
+            .downcast_ref::<ShadowError>()
+            .map(|e| matches!(e, ShadowError::LockHeld { .. }))
+            .unwrap_or(false));
+
+        // Nothing was touched: lock intact, stash still present, worktree unchanged.
+        assert!(git.shadow_dir.join("lock").exists());
+        assert!(git.shadow_dir.join("stash").join("CLAUDE.md").exists());
+        assert_eq!(
+            std::fs::read_to_string(git.root.join("CLAUDE.md")).unwrap(),
+            "# Team\n"
+        );
+    }
+
     /// Helper that runs restore logic directly (bypassing cwd discovery)
     fn restore_for_test(git: &GitRepo, file: Option<&str>) {
-        let stash_dir = git.shadow_dir.join("stash");
-        if stash_dir.exists() {
-            let entries: Vec<_> = std::fs::read_dir(&stash_dir)
-                .unwrap()
-                .filter_map(|e| e.ok())
-                .filter(|e| e.file_type().map(|t| t.is_file()).unwrap_or(false))
-                .collect();
-
-            for entry in entries {
-                let filename = entry.file_name();
-                let encoded = filename.to_string_lossy().to_string();
-                let normalized = path::decode_path(&encoded);
-
-                if let Some(target) = file {
-                    if normalized != target {
-                        continue;
-                    }
-                }
-
-                let worktree_path = git.root.join(&normalized);
-                if let Some(parent) = worktree_path.parent() {
-                    std::fs::create_dir_all(parent).unwrap();
-                }
-                let content = std::fs::read(entry.path()).unwrap();
-                std::fs::write(&worktree_path, &content).unwrap();
-                std::fs::remove_file(entry.path()).unwrap();
-            }
-        }
-
-        if git.shadow_dir.join("lock").exists() {
-            lock::release_lock(&git.shadow_dir).unwrap();
-        }
+        run_with(git, file, ui::UiLocale::En).unwrap();
     }
 }

--- a/src/commands/resume.rs
+++ b/src/commands/resume.rs
@@ -89,56 +89,79 @@ fn resume_overlay(
     let old_baseline = std::fs::read_to_string(&baseline_path)
         .with_context(|| format!("failed to read baseline for {}", file_path))?;
 
+    // Current working-tree content (if any). Used to detect edits made while suspended.
+    let current = std::fs::read_to_string(&worktree_path).ok();
+
     // Get current HEAD content for this file
     let new_baseline = match git.show_file("HEAD", file_path) {
-        Ok(content) => String::from_utf8_lossy(&content).to_string(),
-        Err(_) => {
-            // File deleted in new branch — just restore the suspended content
-            std::fs::write(&worktree_path, suspended_content.as_bytes())
-                .with_context(|| format!("failed to restore {}", file_path))?;
+        Ok(content) => Some(String::from_utf8_lossy(&content).to_string()),
+        Err(_) => None,
+    };
+
+    // Determine what we would write to the working tree, plus any baseline/commit update.
+    let mut baseline_update: Option<String> = None;
+    let mut had_conflicts = false;
+    let incoming = match &new_baseline {
+        // File deleted in the new branch: restore the suspended content as-is.
+        None => suspended_content.clone(),
+        Some(nb) if *nb == old_baseline => {
+            // Baseline unchanged — restore suspended content directly.
+            suspended_content.clone()
+        }
+        Some(nb) => {
+            // Baseline changed — 3-way merge.
+            let merge_result =
+                merge::three_way_merge(&old_baseline, &suspended_content, nb, &git.shadow_dir)?;
+            baseline_update = Some(nb.clone());
+            had_conflicts = merge_result.has_conflicts;
+            merge_result.content
+        }
+    };
+
+    // Edit-safety: refuse to clobber working-tree edits made during suspension. The
+    // working tree is "untouched" if it still matches what suspend left (old baseline),
+    // what git would have produced (new baseline), or the content we are about to write.
+    if let Some(cur) = &current {
+        let matches_expected = *cur == old_baseline
+            || new_baseline.as_deref() == Some(cur.as_str())
+            || *cur == incoming;
+        if !matches_expected {
+            return Err(ShadowError::ResumeEditConflict(file_path.to_string()).into());
+        }
+    }
+
+    std::fs::write(&worktree_path, incoming.as_bytes())
+        .with_context(|| format!("failed to restore {}", file_path))?;
+
+    match (&new_baseline, baseline_update) {
+        (None, _) => {
             println!(
                 "{}",
                 ui::resume_restored_file_absent_from_head(ui::detect_locale(), file_path)
             );
-            return Ok(());
         }
-    };
-
-    if old_baseline == new_baseline {
-        // Baseline unchanged — restore suspended content directly
-        std::fs::write(&worktree_path, suspended_content.as_bytes())
-            .with_context(|| format!("failed to restore {}", file_path))?;
-        println!(
-            "{}",
-            ui::resume_restored_shadow_changes(ui::detect_locale(), file_path)
-        );
-    } else {
-        // Baseline changed — 3-way merge
-        let merge_result = merge::three_way_merge(
-            &old_baseline,
-            &suspended_content,
-            &new_baseline,
-            &git.shadow_dir,
-        )?;
-
-        std::fs::write(&worktree_path, merge_result.content.as_bytes())
-            .with_context(|| format!("failed to write merged content for {}", file_path))?;
-
-        // Update baseline
-        fs_util::atomic_write(&baseline_path, new_baseline.as_bytes())
-            .with_context(|| format!("failed to update baseline for {}", file_path))?;
-
-        if let Some(entry) = config.files.get_mut(file_path) {
-            entry.baseline_commit = Some(new_head.to_string());
-        }
-
-        if merge_result.has_conflicts {
-            eprintln!(
+        (Some(_), None) => {
+            println!(
                 "{}",
-                ui::resume_conflicts(ui::detect_locale(), file_path).yellow()
+                ui::resume_restored_shadow_changes(ui::detect_locale(), file_path)
             );
-        } else {
-            println!("{}", ui::resume_merged(ui::detect_locale(), file_path));
+        }
+        (Some(_), Some(new_baseline_content)) => {
+            fs_util::atomic_write(&baseline_path, new_baseline_content.as_bytes())
+                .with_context(|| format!("failed to update baseline for {}", file_path))?;
+
+            if let Some(entry) = config.files.get_mut(file_path) {
+                entry.baseline_commit = Some(new_head.to_string());
+            }
+
+            if had_conflicts {
+                eprintln!(
+                    "{}",
+                    ui::resume_conflicts(ui::detect_locale(), file_path).yellow()
+                );
+            } else {
+                println!("{}", ui::resume_merged(ui::detect_locale(), file_path));
+            }
         }
     }
 
@@ -160,6 +183,14 @@ fn resume_phantom(git: &GitRepo, suspended_dir: &std::path::Path, file_path: &st
 
     let content = std::fs::read(&suspend_path)
         .with_context(|| format!("failed to read suspended content for {}", file_path))?;
+
+    // Edit-safety: suspend removed the phantom, so the working tree should be absent. If a
+    // file reappeared with different content while suspended, refuse to overwrite it.
+    if let Ok(current) = std::fs::read(&worktree_path) {
+        if current != content {
+            return Err(ShadowError::ResumeEditConflict(file_path.to_string()).into());
+        }
+    }
 
     // Ensure parent directory exists
     if let Some(parent) = worktree_path.parent() {
@@ -372,6 +403,64 @@ mod tests {
     fn test_resume_not_suspended_is_error() {
         let config = ShadowConfig::new();
         assert!(!config.suspended);
+    }
+
+    #[test]
+    fn test_resume_overlay_refuses_when_worktree_edited() {
+        let (_dir, git) = make_test_repo();
+        let commit = git.head_commit().unwrap();
+        let mut config = ShadowConfig::new();
+
+        let baseline_content = git.show_file("HEAD", "CLAUDE.md").unwrap();
+        let encoded = path::encode_path("CLAUDE.md");
+        fs_util::atomic_write(
+            &git.shadow_dir.join("baselines").join(&encoded),
+            &baseline_content,
+        )
+        .unwrap();
+        config
+            .add_overlay("CLAUDE.md".to_string(), commit.clone())
+            .unwrap();
+
+        let suspended_dir = git.shadow_dir.join("suspended");
+        std::fs::create_dir_all(&suspended_dir).unwrap();
+        fs_util::atomic_write(&suspended_dir.join(&encoded), b"# Team\n# My shadow\n").unwrap();
+
+        // User edited the file while suspended (differs from baseline AND suspended content).
+        std::fs::write(
+            git.root.join("CLAUDE.md"),
+            "# Team\n# Edited while suspended\n",
+        )
+        .unwrap();
+
+        let err = super::resume_overlay(&git, &mut config, &suspended_dir, "CLAUDE.md", &commit)
+            .unwrap_err();
+        assert!(err.to_string().contains("overwrite"));
+
+        // Working tree edit must be preserved and suspended content kept.
+        let wt = std::fs::read_to_string(git.root.join("CLAUDE.md")).unwrap();
+        assert_eq!(wt, "# Team\n# Edited while suspended\n");
+        assert!(suspended_dir.join(&encoded).exists());
+    }
+
+    #[test]
+    fn test_resume_phantom_refuses_when_worktree_edited() {
+        let (_dir, git) = make_test_repo();
+
+        let suspended_dir = git.shadow_dir.join("suspended");
+        std::fs::create_dir_all(&suspended_dir).unwrap();
+        let encoded = path::encode_path("local.md");
+        fs_util::atomic_write(&suspended_dir.join(&encoded), b"# Local\n").unwrap();
+
+        // A file reappeared at that path with different content during suspension.
+        std::fs::write(git.root.join("local.md"), "# Different\n").unwrap();
+
+        let err = super::resume_phantom(&git, &suspended_dir, "local.md").unwrap_err();
+        assert!(err.to_string().contains("overwrite"));
+
+        let wt = std::fs::read_to_string(git.root.join("local.md")).unwrap();
+        assert_eq!(wt, "# Different\n");
+        assert!(suspended_dir.join(&encoded).exists());
     }
 
     #[test]

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -1,7 +1,8 @@
 use anyhow::Result;
 use colored::Colorize;
+use serde::Serialize;
 
-use crate::config::{FileType, ShadowConfig};
+use crate::config::{ExcludeMode, FileType, ShadowConfig};
 use crate::git::GitRepo;
 use crate::lock::{self, LockStatus};
 use crate::path;
@@ -15,10 +16,183 @@ enum OverlayGitState {
     PartiallyStaged,
 }
 
-pub fn run(show_git_status: bool) -> Result<()> {
+/// Machine-readable status report (stable English keys/values, not localized).
+#[derive(Serialize)]
+struct StatusReport {
+    suspended: bool,
+    /// Stable warning tokens, e.g. "stash_remaining", "stale_lock".
+    warnings: Vec<String>,
+    files: Vec<FileReport>,
+}
+
+#[derive(Serialize)]
+struct FileReport {
+    path: String,
+    #[serde(rename = "type")]
+    file_type: String,
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    is_directory: bool,
+    /// Whether the target exists in the working tree.
+    exists: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    baseline_commit: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    shadow_added: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    shadow_removed: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    git_state: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    baseline_outdated: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    exclude_mode: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    size_bytes: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    entry_count: Option<usize>,
+}
+
+fn git_state_json(state: OverlayGitState) -> &'static str {
+    match state {
+        OverlayGitState::Clean => "clean",
+        OverlayGitState::Modified => "modified",
+        OverlayGitState::Staged => "staged",
+        OverlayGitState::PartiallyStaged => "partially_staged",
+    }
+}
+
+fn exclude_mode_json(mode: &ExcludeMode) -> &'static str {
+    match mode {
+        ExcludeMode::GitInfoExclude => "git_info_exclude",
+        ExcludeMode::None => "none",
+    }
+}
+
+/// Build the machine-readable report from config + working-tree state.
+fn build_report(git: &GitRepo, config: &ShadowConfig) -> Result<StatusReport> {
+    let mut warnings = Vec::new();
+
+    let stash_dir = git.shadow_dir.join("stash");
+    if stash_dir.exists() {
+        let has_files = std::fs::read_dir(&stash_dir)?
+            .filter_map(|e| e.ok())
+            .any(|e| e.file_type().map(|t| t.is_file()).unwrap_or(false));
+        if has_files {
+            warnings.push("stash_remaining".to_string());
+        }
+    }
+
+    if let LockStatus::Stale(_) = lock::check_lock(&git.shadow_dir)? {
+        warnings.push("stale_lock".to_string());
+    }
+
+    let mut files = Vec::new();
+    for (file_path, entry) in &config.files {
+        let worktree_path = git.root.join(file_path);
+        match entry.file_type {
+            FileType::Overlay => {
+                let encoded = path::encode_path(file_path);
+                let baseline_path = git.shadow_dir.join("baselines").join(&encoded);
+                let exists = worktree_path.exists();
+
+                let mut shadow_added = None;
+                let mut shadow_removed = None;
+                let mut git_state = None;
+                let mut baseline_outdated = None;
+
+                if exists && baseline_path.exists() {
+                    let baseline = std::fs::read_to_string(&baseline_path).unwrap_or_default();
+                    let current = std::fs::read_to_string(&worktree_path).unwrap_or_default();
+                    let (added, removed) = diff_stats(&baseline, &current);
+                    shadow_added = Some(added);
+                    shadow_removed = Some(removed);
+
+                    let state = overlay_git_state(git.staging_status(file_path)?);
+                    git_state = Some(git_state_json(state).to_string());
+
+                    if let Some(ref commit) = entry.baseline_commit {
+                        if let Ok(head) = git.head_commit() {
+                            let outdated = *commit != head
+                                && git
+                                    .show_file("HEAD", file_path)
+                                    .ok()
+                                    .map(|head_content| {
+                                        std::fs::read(&baseline_path).unwrap_or_default()
+                                            != head_content
+                                    })
+                                    .unwrap_or(false);
+                            baseline_outdated = Some(outdated);
+                        }
+                    }
+                }
+
+                files.push(FileReport {
+                    path: file_path.clone(),
+                    file_type: "overlay".to_string(),
+                    is_directory: false,
+                    exists,
+                    baseline_commit: entry.baseline_commit.clone(),
+                    shadow_added,
+                    shadow_removed,
+                    git_state,
+                    baseline_outdated,
+                    exclude_mode: None,
+                    size_bytes: None,
+                    entry_count: None,
+                });
+            }
+            FileType::Phantom => {
+                let (exists, size_bytes, entry_count) = if entry.is_directory {
+                    if worktree_path.is_dir() {
+                        let count = std::fs::read_dir(&worktree_path)
+                            .map(|entries| entries.count())
+                            .unwrap_or(0);
+                        (true, None, Some(count))
+                    } else {
+                        (false, None, None)
+                    }
+                } else if worktree_path.exists() {
+                    let size = std::fs::metadata(&worktree_path).map(|m| m.len()).ok();
+                    (true, size, None)
+                } else {
+                    (false, None, None)
+                };
+
+                files.push(FileReport {
+                    path: file_path.clone(),
+                    file_type: "phantom".to_string(),
+                    is_directory: entry.is_directory,
+                    exists,
+                    baseline_commit: None,
+                    shadow_added: None,
+                    shadow_removed: None,
+                    git_state: None,
+                    baseline_outdated: None,
+                    exclude_mode: Some(exclude_mode_json(&entry.exclude_mode).to_string()),
+                    size_bytes,
+                    entry_count,
+                });
+            }
+        }
+    }
+
+    Ok(StatusReport {
+        suspended: config.suspended,
+        warnings,
+        files,
+    })
+}
+
+pub fn run(show_git_status: bool, json: bool) -> Result<()> {
     let locale = ui::detect_locale();
     let git = GitRepo::discover(&std::env::current_dir()?)?;
     let config = ShadowConfig::load(&git.shadow_dir)?;
+
+    if json {
+        let report = build_report(&git, &config)?;
+        println!("{}", serde_json::to_string_pretty(&report)?);
+        return Ok(());
+    }
 
     if show_git_status {
         print!("{}", git.status_short()?);
@@ -294,5 +468,94 @@ mod tests {
     #[test]
     fn test_format_size_mb() {
         assert_eq!(format_size(1_572_864), "1.5 MB");
+    }
+
+    fn make_test_repo() -> (tempfile::TempDir, GitRepo) {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().to_path_buf();
+        for args in [
+            vec!["init"],
+            vec!["config", "user.name", "Test"],
+            vec!["config", "user.email", "t@t.com"],
+        ] {
+            std::process::Command::new("git")
+                .args(&args)
+                .current_dir(&root)
+                .output()
+                .unwrap();
+        }
+        std::fs::write(root.join("CLAUDE.md"), "# Team\n").unwrap();
+        std::process::Command::new("git")
+            .args(["add", "CLAUDE.md"])
+            .current_dir(&root)
+            .output()
+            .unwrap();
+        std::process::Command::new("git")
+            .args(["commit", "-m", "init"])
+            .current_dir(&root)
+            .output()
+            .unwrap();
+
+        let repo = GitRepo::discover(&root).unwrap();
+        std::fs::create_dir_all(repo.shadow_dir.join("baselines")).unwrap();
+        std::fs::create_dir_all(repo.shadow_dir.join("stash")).unwrap();
+        (dir, repo)
+    }
+
+    #[test]
+    fn test_build_report_overlay_json_keys() {
+        let (_dir, git) = make_test_repo();
+        let mut config = ShadowConfig::new();
+        let commit = git.head_commit().unwrap();
+        let baseline = git.show_file("HEAD", "CLAUDE.md").unwrap();
+        let encoded = crate::path::encode_path("CLAUDE.md");
+        crate::fs_util::atomic_write(&git.shadow_dir.join("baselines").join(&encoded), &baseline)
+            .unwrap();
+        config.add_overlay("CLAUDE.md".to_string(), commit).unwrap();
+        std::fs::write(git.root.join("CLAUDE.md"), "# Team\n# shadow\n").unwrap();
+
+        let report = build_report(&git, &config).unwrap();
+        let value = serde_json::to_value(&report).unwrap();
+
+        assert_eq!(value["suspended"], false);
+        assert!(value["warnings"].as_array().unwrap().is_empty());
+        let file = &value["files"][0];
+        assert_eq!(file["path"], "CLAUDE.md");
+        assert_eq!(file["type"], "overlay");
+        assert_eq!(file["exists"], true);
+        assert_eq!(file["shadow_added"], 1);
+        assert_eq!(file["git_state"], "modified");
+    }
+
+    #[test]
+    fn test_build_report_phantom_json_keys() {
+        let (_dir, git) = make_test_repo();
+        let mut config = ShadowConfig::new();
+        std::fs::write(git.root.join("local.md"), "hello").unwrap();
+        config
+            .add_phantom(
+                "local.md".to_string(),
+                crate::config::ExcludeMode::GitInfoExclude,
+                false,
+            )
+            .unwrap();
+
+        let report = build_report(&git, &config).unwrap();
+        let value = serde_json::to_value(&report).unwrap();
+        let file = &value["files"][0];
+        assert_eq!(file["type"], "phantom");
+        assert_eq!(file["exists"], true);
+        assert_eq!(file["exclude_mode"], "git_info_exclude");
+        assert_eq!(file["size_bytes"], 5);
+    }
+
+    #[test]
+    fn test_build_report_warns_on_stash_remnant() {
+        let (_dir, git) = make_test_repo();
+        let config = ShadowConfig::new();
+        std::fs::write(git.shadow_dir.join("stash").join("old.md"), "x").unwrap();
+
+        let report = build_report(&git, &config).unwrap();
+        assert!(report.warnings.contains(&"stash_remaining".to_string()));
     }
 }

--- a/src/commands/suspend.rs
+++ b/src/commands/suspend.rs
@@ -40,26 +40,7 @@ pub fn run() -> Result<()> {
         return Ok(());
     }
 
-    // Create suspended directory
-    let suspended_dir = git.shadow_dir.join("suspended");
-    std::fs::create_dir_all(&suspended_dir).context("failed to create suspended directory")?;
-
-    let mut count = 0;
-
-    for (file_path, entry) in &config.files {
-        match entry.file_type {
-            FileType::Overlay => {
-                suspend_overlay(&git, &suspended_dir, file_path)?;
-                count += 1;
-            }
-            FileType::Phantom => {
-                if !entry.is_directory {
-                    suspend_phantom(&git, &suspended_dir, file_path)?;
-                    count += 1;
-                }
-            }
-        }
-    }
+    let count = perform_suspend(&git, &config)?;
 
     config.suspended = true;
     config.save(&git.shadow_dir)?;
@@ -70,34 +51,88 @@ pub fn run() -> Result<()> {
     Ok(())
 }
 
+/// Move all shadow changes into `suspended/`, restoring baselines / removing phantoms.
+///
+/// If any file fails mid-loop, the files already suspended are rolled back to the working
+/// tree so no changes are orphaned, and the error is returned.
+fn perform_suspend(git: &GitRepo, config: &ShadowConfig) -> Result<usize> {
+    let suspended_dir = git.shadow_dir.join("suspended");
+    std::fs::create_dir_all(&suspended_dir).context("failed to create suspended directory")?;
+
+    // Track paths that were actually moved into suspended/ so we can undo them.
+    let mut suspended: Vec<String> = Vec::new();
+
+    for (file_path, entry) in &config.files {
+        let step = match entry.file_type {
+            FileType::Overlay => suspend_overlay(git, &suspended_dir, file_path).map(|_| true),
+            FileType::Phantom if !entry.is_directory => {
+                suspend_phantom(git, &suspended_dir, file_path)
+            }
+            FileType::Phantom => Ok(false),
+        };
+
+        match step {
+            Ok(true) => suspended.push(file_path.clone()),
+            Ok(false) => {}
+            Err(e) => {
+                rollback_suspend(git, &suspended_dir, &suspended);
+                return Err(e);
+            }
+        }
+    }
+
+    Ok(suspended.len())
+}
+
+/// Restore already-suspended files back to the working tree and drop their suspended copy.
+fn rollback_suspend(git: &GitRepo, suspended_dir: &std::path::Path, suspended: &[String]) {
+    for file_path in suspended {
+        let encoded = path::encode_path(file_path);
+        let suspend_path = suspended_dir.join(&encoded);
+        let worktree_path = git.root.join(file_path);
+        if let Ok(content) = std::fs::read(&suspend_path) {
+            let _ = std::fs::write(&worktree_path, &content);
+            let _ = std::fs::remove_file(&suspend_path);
+        }
+    }
+}
+
 fn suspend_overlay(git: &GitRepo, suspended_dir: &std::path::Path, file_path: &str) -> Result<()> {
     let encoded = path::encode_path(file_path);
     let worktree_path = git.root.join(file_path);
     let baseline_path = git.shadow_dir.join("baselines").join(&encoded);
     let suspend_path = suspended_dir.join(&encoded);
 
-    // Save current working tree content (with shadow changes) to suspended/
+    // Read both inputs BEFORE mutating anything, so a read failure leaves no partial state.
     let content =
         std::fs::read(&worktree_path).with_context(|| format!("failed to read {}", file_path))?;
+    let baseline = std::fs::read(&baseline_path)
+        .with_context(|| format!("failed to read baseline for {}", file_path))?;
+
+    // Save current working tree content (with shadow changes) to suspended/
     fs_util::atomic_write(&suspend_path, &content)
         .with_context(|| format!("failed to save suspended content for {}", file_path))?;
 
     // Restore baseline content to working tree
-    let baseline = std::fs::read(&baseline_path)
-        .with_context(|| format!("failed to read baseline for {}", file_path))?;
     std::fs::write(&worktree_path, &baseline)
         .with_context(|| format!("failed to restore baseline for {}", file_path))?;
 
     Ok(())
 }
 
-fn suspend_phantom(git: &GitRepo, suspended_dir: &std::path::Path, file_path: &str) -> Result<()> {
+/// Returns `true` if the phantom was present and suspended, `false` if there was nothing
+/// to suspend (file absent).
+fn suspend_phantom(
+    git: &GitRepo,
+    suspended_dir: &std::path::Path,
+    file_path: &str,
+) -> Result<bool> {
     let encoded = path::encode_path(file_path);
     let worktree_path = git.root.join(file_path);
     let suspend_path = suspended_dir.join(&encoded);
 
     if !worktree_path.exists() {
-        return Ok(());
+        return Ok(false);
     }
 
     // Save phantom content to suspended/
@@ -110,7 +145,7 @@ fn suspend_phantom(git: &GitRepo, suspended_dir: &std::path::Path, file_path: &s
     std::fs::remove_file(&worktree_path)
         .with_context(|| format!("failed to remove {} from working tree", file_path))?;
 
-    Ok(())
+    Ok(true)
 }
 
 #[cfg(test)]
@@ -257,6 +292,52 @@ mod tests {
         // Should detect already suspended via config
         let loaded = ShadowConfig::load(&git.shadow_dir).unwrap();
         assert!(loaded.suspended);
+    }
+
+    #[test]
+    fn test_perform_suspend_rolls_back_on_failure() {
+        let (_dir, git) = make_test_repo();
+        let commit = git.head_commit().unwrap();
+        let mut config = ShadowConfig::new();
+
+        // Overlay "a.md": has a baseline and will suspend successfully.
+        std::fs::write(git.root.join("a.md"), "a-shadow\n").unwrap();
+        let a_encoded = path::encode_path("a.md");
+        fs_util::atomic_write(
+            &git.shadow_dir.join("baselines").join(&a_encoded),
+            b"a-base\n",
+        )
+        .unwrap();
+        config
+            .add_overlay("a.md".to_string(), commit.clone())
+            .unwrap();
+
+        // Overlay "b.md": no baseline file -> suspend will fail (a < b, so a runs first).
+        std::fs::write(git.root.join("b.md"), "b-shadow\n").unwrap();
+        config.add_overlay("b.md".to_string(), commit).unwrap();
+
+        let result = super::perform_suspend(&git, &config);
+        assert!(result.is_err(), "suspend should fail on missing baseline");
+
+        // "a.md" must be rolled back to its original shadow content.
+        let a_content = std::fs::read_to_string(git.root.join("a.md")).unwrap();
+        assert_eq!(
+            a_content, "a-shadow\n",
+            "already-suspended file must be restored"
+        );
+
+        // No orphaned suspended files should remain.
+        let suspended_dir = git.shadow_dir.join("suspended");
+        let leftovers: Vec<_> = std::fs::read_dir(&suspended_dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_type().map(|t| t.is_file()).unwrap_or(false))
+            .collect();
+        assert!(
+            leftovers.is_empty(),
+            "no suspended files should be orphaned, found: {:?}",
+            leftovers
+        );
     }
 
     #[test]

--- a/src/commands/uninstall.rs
+++ b/src/commands/uninstall.rs
@@ -1,0 +1,305 @@
+use anyhow::{Context, Result};
+use colored::Colorize;
+
+use crate::config::{FileType, ShadowConfig};
+use crate::error::ShadowError;
+use crate::exclude::{self, ExcludeManager};
+use crate::git::GitRepo;
+use crate::lock::{self, LockStatus};
+use crate::path;
+use crate::ui;
+
+const HOOK_NAMES: &[&str] = &["pre-commit", "post-commit", "post-merge", "post-rewrite"];
+
+pub fn run(force: bool) -> Result<()> {
+    let locale = ui::detect_locale();
+    let git = GitRepo::discover(&std::env::current_dir()?)?;
+    let config = ShadowConfig::load(&git.shadow_dir)?;
+
+    // Refuse while a commit is in progress: leftover stash or a live lock means
+    // pre-commit ran but post-commit has not, so wiping state would lose work.
+    guard_commit_in_progress(&git)?;
+
+    // Refuse if files are still managed, unless --force restores overlays and wipes.
+    if !config.files.is_empty() && !force {
+        return Err(ShadowError::UninstallHasEntries(config.files.len()).into());
+    }
+
+    // --force: restore overlay baselines to the working tree; phantom files are left
+    // untouched on disk (they are the user's local-only files).
+    if force {
+        let restored = restore_overlays(&git, &config)?;
+        if restored > 0 {
+            println!(
+                "{}",
+                ui::uninstall_forced_overlays(locale, restored).green()
+            );
+        }
+    }
+
+    // Remove the shadow hooks from the effective hooks dir, restoring any pre-shadow
+    // backups made by install (mirrors install's chaining/backup logic).
+    remove_hooks(&git, locale)?;
+
+    // Regenerate the shared exclude section from the OTHER worktrees' configs only.
+    // Passing an empty config for the current worktree drops entries this worktree
+    // owned while preserving those another worktree still relies on.
+    let manager = ExcludeManager::new(&git.common_dir);
+    let patterns = exclude::union_patterns(&git, &ShadowConfig::new());
+    manager.set_entries(&patterns)?;
+
+    // Remove this worktree's shadow state (git_dir-based, per-worktree).
+    if git.shadow_dir.exists() {
+        std::fs::remove_dir_all(&git.shadow_dir)
+            .with_context(|| format!("failed to remove {}", git.shadow_dir.display()))?;
+    }
+
+    println!("{}", ui::uninstall_success(locale).green());
+    Ok(())
+}
+
+/// Block uninstall when a commit cycle appears to be mid-flight.
+fn guard_commit_in_progress(git: &GitRepo) -> Result<()> {
+    let stash_dir = git.shadow_dir.join("stash");
+    if stash_dir.exists() {
+        let has_files = std::fs::read_dir(&stash_dir)
+            .ok()
+            .map(|entries| {
+                entries
+                    .filter_map(|e| e.ok())
+                    .any(|e| e.file_type().map(|t| t.is_file()).unwrap_or(false))
+            })
+            .unwrap_or(false);
+        if has_files {
+            return Err(ShadowError::StashRemaining.into());
+        }
+    }
+
+    if let Ok(LockStatus::HeldByOther(info)) = lock::check_lock(&git.shadow_dir) {
+        return Err(ShadowError::LockHeld {
+            pid: info.pid,
+            timestamp: info.timestamp.to_rfc3339(),
+        }
+        .into());
+    }
+
+    Ok(())
+}
+
+/// Restore overlay baselines to the working tree. Returns the number restored.
+fn restore_overlays(git: &GitRepo, config: &ShadowConfig) -> Result<usize> {
+    let mut restored = 0;
+    for (file_path, entry) in &config.files {
+        if entry.file_type != FileType::Overlay {
+            continue;
+        }
+        let encoded = path::encode_path(file_path);
+        let baseline_path = git.shadow_dir.join("baselines").join(&encoded);
+        if baseline_path.exists() {
+            let baseline = std::fs::read(&baseline_path)?;
+            let worktree_path = git.root.join(file_path);
+            std::fs::write(&worktree_path, &baseline)
+                .with_context(|| format!("failed to restore baseline to {}", file_path))?;
+            restored += 1;
+        }
+    }
+    Ok(restored)
+}
+
+/// Remove shadow hooks from the effective hooks dir, restoring pre-shadow backups.
+fn remove_hooks(git: &GitRepo, locale: ui::UiLocale) -> Result<()> {
+    let hooks_dir = git.effective_hooks_dir();
+
+    for hook_name in HOOK_NAMES {
+        let hook_path = hooks_dir.join(hook_name);
+        let backup = hooks_dir.join(format!("{}.pre-shadow", hook_name));
+
+        // Only remove hooks we installed (they dispatch to git-shadow). Leave any
+        // unrelated user hook in place.
+        if let Ok(content) = std::fs::read_to_string(&hook_path) {
+            if content.contains("git-shadow hook") {
+                std::fs::remove_file(&hook_path)
+                    .with_context(|| format!("failed to remove {}", hook_name))?;
+            }
+        }
+
+        // Restore the pre-existing hook we backed up during install.
+        if backup.exists() {
+            std::fs::rename(&backup, &hook_path)
+                .with_context(|| format!("failed to restore {}", hook_name))?;
+            println!("{}", ui::uninstall_hook_restored(locale, hook_name));
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::ExcludeMode;
+    use std::os::unix::fs::PermissionsExt;
+
+    fn make_test_repo() -> (tempfile::TempDir, GitRepo) {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().to_path_buf();
+        for args in [
+            vec!["init"],
+            vec!["config", "user.name", "Test"],
+            vec!["config", "user.email", "t@t.com"],
+        ] {
+            std::process::Command::new("git")
+                .args(&args)
+                .current_dir(&root)
+                .output()
+                .unwrap();
+        }
+        std::fs::write(root.join("CLAUDE.md"), "# Team\n").unwrap();
+        std::process::Command::new("git")
+            .args(["add", "CLAUDE.md"])
+            .current_dir(&root)
+            .output()
+            .unwrap();
+        std::process::Command::new("git")
+            .args(["commit", "-m", "init"])
+            .current_dir(&root)
+            .output()
+            .unwrap();
+
+        let repo = GitRepo::discover(&root).unwrap();
+        std::fs::create_dir_all(repo.shadow_dir.join("baselines")).unwrap();
+        std::fs::create_dir_all(repo.shadow_dir.join("stash")).unwrap();
+        (dir, repo)
+    }
+
+    fn write_shadow_hook(git: &GitRepo, name: &str) {
+        let hooks_dir = git.effective_hooks_dir();
+        std::fs::create_dir_all(&hooks_dir).unwrap();
+        let content = format!("#!/bin/sh\ngit-shadow hook {}\n", name);
+        std::fs::write(hooks_dir.join(name), &content).unwrap();
+        std::fs::set_permissions(hooks_dir.join(name), std::fs::Permissions::from_mode(0o755))
+            .unwrap();
+    }
+
+    #[test]
+    fn test_remove_hooks_deletes_shadow_hooks() {
+        let (_dir, git) = make_test_repo();
+        for name in HOOK_NAMES {
+            write_shadow_hook(&git, name);
+        }
+
+        remove_hooks(&git, ui::UiLocale::En).unwrap();
+
+        for name in HOOK_NAMES {
+            assert!(
+                !git.effective_hooks_dir().join(name).exists(),
+                "{} should be removed",
+                name
+            );
+        }
+    }
+
+    #[test]
+    fn test_remove_hooks_restores_pre_shadow_backup() {
+        let (_dir, git) = make_test_repo();
+        let hooks_dir = git.effective_hooks_dir();
+        std::fs::create_dir_all(&hooks_dir).unwrap();
+
+        // Shadow hook plus a backed-up original.
+        write_shadow_hook(&git, "pre-commit");
+        std::fs::write(
+            hooks_dir.join("pre-commit.pre-shadow"),
+            "#!/bin/sh\necho original\n",
+        )
+        .unwrap();
+
+        remove_hooks(&git, ui::UiLocale::En).unwrap();
+
+        let restored = std::fs::read_to_string(hooks_dir.join("pre-commit")).unwrap();
+        assert!(restored.contains("echo original"));
+        assert!(!hooks_dir.join("pre-commit.pre-shadow").exists());
+    }
+
+    #[test]
+    fn test_remove_hooks_leaves_unrelated_hook() {
+        let (_dir, git) = make_test_repo();
+        let hooks_dir = git.effective_hooks_dir();
+        std::fs::create_dir_all(&hooks_dir).unwrap();
+        std::fs::write(hooks_dir.join("pre-commit"), "#!/bin/sh\necho user\n").unwrap();
+
+        remove_hooks(&git, ui::UiLocale::En).unwrap();
+
+        assert!(hooks_dir.join("pre-commit").exists());
+    }
+
+    #[test]
+    fn test_restore_overlays_writes_baseline_to_worktree() {
+        let (_dir, git) = make_test_repo();
+        let mut config = ShadowConfig::new();
+        let commit = git.head_commit().unwrap();
+        let baseline = git.show_file("HEAD", "CLAUDE.md").unwrap();
+        let encoded = path::encode_path("CLAUDE.md");
+        crate::fs_util::atomic_write(&git.shadow_dir.join("baselines").join(&encoded), &baseline)
+            .unwrap();
+        config.add_overlay("CLAUDE.md".to_string(), commit).unwrap();
+
+        // Local shadow edit in the working tree.
+        std::fs::write(git.root.join("CLAUDE.md"), "# Team\n# shadow\n").unwrap();
+
+        let restored = restore_overlays(&git, &config).unwrap();
+        assert_eq!(restored, 1);
+        assert_eq!(
+            std::fs::read_to_string(git.root.join("CLAUDE.md")).unwrap(),
+            "# Team\n"
+        );
+    }
+
+    #[test]
+    fn test_guard_refuses_on_stash_remnant() {
+        let (_dir, git) = make_test_repo();
+        std::fs::write(git.shadow_dir.join("stash").join("old.md"), "x").unwrap();
+        let result = guard_commit_in_progress(&git);
+        assert!(matches!(
+            result.unwrap_err().downcast_ref::<ShadowError>(),
+            Some(ShadowError::StashRemaining)
+        ));
+    }
+
+    #[test]
+    fn test_uninstall_refuses_with_active_entries() {
+        let (_dir, git) = make_test_repo();
+        let mut config = ShadowConfig::new();
+        config
+            .add_phantom("local.md".to_string(), ExcludeMode::None, false)
+            .unwrap();
+        config.save(&git.shadow_dir).unwrap();
+
+        // Mirror run()'s refusal logic without touching cwd.
+        assert!(!config.files.is_empty());
+        let err = ShadowError::UninstallHasEntries(config.files.len());
+        assert!(matches!(err, ShadowError::UninstallHasEntries(1)));
+    }
+
+    #[test]
+    fn test_clean_uninstall_removes_state_and_hooks() {
+        let (_dir, git) = make_test_repo();
+        for name in HOOK_NAMES {
+            write_shadow_hook(&git, name);
+        }
+        let config = ShadowConfig::new();
+        config.save(&git.shadow_dir).unwrap();
+
+        // Simulate the core of run() for an empty config.
+        guard_commit_in_progress(&git).unwrap();
+        remove_hooks(&git, ui::UiLocale::En).unwrap();
+        let manager = ExcludeManager::new(&git.common_dir);
+        let patterns = exclude::union_patterns(&git, &ShadowConfig::new());
+        manager.set_entries(&patterns).unwrap();
+        std::fs::remove_dir_all(&git.shadow_dir).unwrap();
+
+        assert!(!git.shadow_dir.exists());
+        for name in HOOK_NAMES {
+            assert!(!git.effective_hooks_dir().join(name).exists());
+        }
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -35,6 +35,12 @@ pub enum ShadowError {
     #[error("stale lock detected (PID {0} no longer exists). Run `git-shadow restore`")]
     StaleLock(u32),
 
+    #[error("lockfile is corrupted (unreadable). Run `git-shadow restore`")]
+    CorruptLock,
+
+    #[error("3-way merge failed: {0}")]
+    MergeFailed(String),
+
     #[error("automatic stale-lock recovery would overwrite newer working tree content in '{0}'. Run `git-shadow restore` manually")]
     AutoRestoreConflict(String),
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -82,6 +82,12 @@ pub enum ShadowError {
     #[error("hooks not installed. Run `git-shadow install`")]
     HooksNotInstalled,
 
+    #[error("{0} file(s) are still managed by git-shadow. Remove them first or pass --force")]
+    UninstallHasEntries(usize),
+
+    #[error("doctor found {0} issue(s)")]
+    DoctorFoundIssues(usize),
+
     #[error("cannot run in non-interactive mode without --force")]
     NonInteractiveWithoutForce,
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -44,6 +44,11 @@ pub enum ShadowError {
     #[error("automatic stale-lock recovery would overwrite newer working tree content in '{0}'. Run `git-shadow restore` manually")]
     AutoRestoreConflict(String),
 
+    #[error(
+        "resume would overwrite working tree edits made to '{0}' while suspended. Resolve manually"
+    )]
+    ResumeEditConflict(String),
+
     #[error("stash has remaining files. Run `git-shadow restore`")]
     StashRemaining,
 

--- a/src/exclude.rs
+++ b/src/exclude.rs
@@ -1,9 +1,89 @@
+use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
+use crate::config::{ExcludeMode, FileType, ShadowConfig};
 use crate::fs_util;
+use crate::git::GitRepo;
 
 const SECTION_START: &str = "# >>> git-shadow managed (DO NOT EDIT) >>>";
 const SECTION_END: &str = "# <<< git-shadow managed <<<";
+
+/// Build an anchored, escaped `.git/info/exclude` pattern for a repo-root-relative path.
+///
+/// - Leading `/` anchors the pattern to the repository root so a top-level `local.md`
+///   does not accidentally exclude files named `local.md` in subdirectories.
+/// - gitignore metacharacters are backslash-escaped so filenames containing them are
+///   matched literally.
+/// - A trailing `/` marks directory entries.
+pub fn to_exclude_pattern(relative_path: &str, is_directory: bool) -> String {
+    let mut pattern = String::with_capacity(relative_path.len() + 4);
+    pattern.push('/');
+    pattern.push_str(&escape_gitignore(relative_path));
+    if is_directory {
+        pattern.push('/');
+    }
+    pattern
+}
+
+/// Escape gitignore special characters. `/` is left intact (it is structural).
+fn escape_gitignore(path: &str) -> String {
+    let mut out = String::with_capacity(path.len() + 4);
+    for (i, ch) in path.chars().enumerate() {
+        match ch {
+            // Glob metacharacters and the escape character itself: always escape.
+            '\\' | '*' | '?' | '[' | ']' => {
+                out.push('\\');
+                out.push(ch);
+            }
+            // `#` (comment) and `!` (negation) only matter at the start of a pattern;
+            // escape them there. Leading whitespace would otherwise be significant/trimmed.
+            '#' | '!' | ' ' | '\t' if i == 0 => {
+                out.push('\\');
+                out.push(ch);
+            }
+            _ => out.push(ch),
+        }
+    }
+    out
+}
+
+/// Compute the union of anchored exclude patterns required across all worktrees.
+///
+/// The `.git/info/exclude` file is shared via `common_dir`, but each worktree keeps its
+/// own shadow config under `git_dir`. To avoid dropping an entry another worktree still
+/// relies on, we union the `GitInfoExclude` phantom patterns from every worktree's config.
+/// The current worktree's in-memory `current` config is used instead of its on-disk copy
+/// (which may not be saved yet).
+pub fn union_patterns(git: &GitRepo, current: &ShadowConfig) -> Vec<String> {
+    let mut patterns = BTreeSet::new();
+    collect_patterns(&mut patterns, current);
+
+    let current_shadow = git.shadow_dir.canonicalize().ok();
+
+    for wt in git.list_worktree_paths() {
+        let Ok(wt_git) = GitRepo::discover(&wt) else {
+            continue;
+        };
+        // Skip the current worktree; its state is provided via `current`.
+        if wt_git.shadow_dir.canonicalize().ok() == current_shadow {
+            continue;
+        }
+        if let Ok(cfg) = ShadowConfig::load(&wt_git.shadow_dir) {
+            collect_patterns(&mut patterns, &cfg);
+        }
+    }
+
+    patterns.into_iter().collect()
+}
+
+fn collect_patterns(patterns: &mut BTreeSet<String>, config: &ShadowConfig) {
+    for (path, entry) in &config.files {
+        if entry.file_type == FileType::Phantom && entry.exclude_mode == ExcludeMode::GitInfoExclude
+        {
+            patterns.insert(to_exclude_pattern(path, entry.is_directory));
+        }
+    }
+}
 
 pub struct ExcludeManager {
     path: PathBuf,
@@ -27,6 +107,17 @@ impl ExcludeManager {
         entries.push(entry_path.to_string());
 
         let new_content = self.rebuild_content(&content, &entries);
+        fs_util::atomic_write(&self.path, new_content.as_bytes())?;
+        Ok(())
+    }
+
+    /// Replace the entire managed section with exactly `entries`.
+    ///
+    /// This regenerates the section from the caller's source of truth (the shadow
+    /// config(s)), so any stale/unanchored entries left by older versions are upgraded.
+    pub fn set_entries(&self, entries: &[String]) -> anyhow::Result<()> {
+        let content = std::fs::read_to_string(&self.path).unwrap_or_default();
+        let new_content = self.rebuild_content(&content, entries);
         fs_util::atomic_write(&self.path, new_content.as_bytes())?;
         Ok(())
     }
@@ -242,5 +333,59 @@ mod tests {
         let (_dir, manager) = setup();
         manager.add_entry("a.md").unwrap();
         assert!(manager.remove_entry("nonexistent.md").is_ok());
+    }
+
+    #[test]
+    fn test_to_exclude_pattern_anchors_file() {
+        assert_eq!(to_exclude_pattern("local.md", false), "/local.md");
+        assert_eq!(
+            to_exclude_pattern("src/components/notes.md", false),
+            "/src/components/notes.md"
+        );
+    }
+
+    #[test]
+    fn test_to_exclude_pattern_anchors_directory() {
+        assert_eq!(to_exclude_pattern(".claude", true), "/.claude/");
+    }
+
+    #[test]
+    fn test_to_exclude_pattern_escapes_metacharacters() {
+        assert_eq!(to_exclude_pattern("a[b]*.md", false), "/a\\[b\\]\\*.md");
+        assert_eq!(to_exclude_pattern("weird?.log", false), "/weird\\?.log");
+    }
+
+    #[test]
+    fn test_to_exclude_pattern_escapes_leading_special_chars() {
+        assert_eq!(to_exclude_pattern("#hash.md", false), "/\\#hash.md");
+        assert_eq!(to_exclude_pattern("!bang.md", false), "/\\!bang.md");
+        assert_eq!(to_exclude_pattern(" spaced.md", false), "/\\ spaced.md");
+    }
+
+    #[test]
+    fn test_set_entries_replaces_stale_unanchored_entries() {
+        let (_dir, manager) = setup();
+        // Stale unanchored entry from an older version.
+        manager.add_entry("local.md").unwrap();
+
+        // Regenerate the section with anchored patterns.
+        manager
+            .set_entries(&["/local.md".to_string(), "/.claude/".to_string()])
+            .unwrap();
+
+        let entries = manager.list_entries().unwrap();
+        assert!(entries.contains(&"/local.md".to_string()));
+        assert!(entries.contains(&"/.claude/".to_string()));
+        assert!(!entries.contains(&"local.md".to_string()));
+    }
+
+    #[test]
+    fn test_set_entries_empty_removes_section() {
+        let (_dir, manager) = setup();
+        manager.add_entry("a.md").unwrap();
+        manager.set_entries(&[]).unwrap();
+
+        let content = std::fs::read_to_string(&manager.path).unwrap_or_default();
+        assert!(!content.contains(SECTION_START));
     }
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -119,9 +119,57 @@ impl GitRepo {
         }
     }
 
-    /// Get the hooks directory (lives under common_dir, shared across worktrees)
+    /// Get the default hooks directory (lives under common_dir, shared across worktrees).
+    ///
+    /// This ignores `core.hooksPath`; use [`GitRepo::effective_hooks_dir`] when you need
+    /// the directory Git actually runs hooks from.
     pub fn hooks_dir(&self) -> PathBuf {
         self.common_dir.join("hooks")
+    }
+
+    /// Read the `core.hooksPath` configuration value.
+    ///
+    /// Returns `None` when it is unset or empty. The value may be absolute or relative;
+    /// relative values are resolved against the working-tree root by
+    /// [`GitRepo::effective_hooks_dir`].
+    pub fn hooks_path_config(&self) -> Option<String> {
+        let output = Command::new("git")
+            .args(["config", "--get", "core.hooksPath"])
+            .current_dir(&self.root)
+            .output()
+            .ok()?;
+
+        if !output.status.success() {
+            return None;
+        }
+
+        let value = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if value.is_empty() {
+            None
+        } else {
+            Some(value)
+        }
+    }
+
+    /// Resolve the effective hooks directory Git will run hooks from.
+    ///
+    /// When `core.hooksPath` is set (e.g. by husky, lefthook, or this repo's own
+    /// `dev-hooks` recommendation), hooks in the default `common_dir/hooks` never run,
+    /// so shadow hooks must be installed into the custom directory instead. When it is
+    /// unset, this falls back to [`GitRepo::hooks_dir`] to preserve worktree semantics
+    /// (hooks are shared via `common_dir`).
+    pub fn effective_hooks_dir(&self) -> PathBuf {
+        match self.hooks_path_config() {
+            Some(hooks_path) => {
+                let path = PathBuf::from(&hooks_path);
+                if path.is_absolute() {
+                    path
+                } else {
+                    self.root.join(path)
+                }
+            }
+            None => self.hooks_dir(),
+        }
     }
 
     /// Enumerate the working-tree paths of all worktrees attached to this repository.
@@ -273,7 +321,7 @@ impl GitRepo {
 
     /// Check if hooks are installed
     pub fn hooks_installed(&self) -> bool {
-        let hooks_dir = self.hooks_dir();
+        let hooks_dir = self.effective_hooks_dir();
         ["pre-commit", "post-commit", "post-merge", "post-rewrite"]
             .iter()
             .all(|name| {
@@ -532,6 +580,39 @@ mod tests {
 
         // git_dir should differ from common_dir in worktree
         assert_ne!(wt_repo.git_dir, wt_repo.common_dir);
+    }
+
+    #[test]
+    fn test_hooks_path_config_none_when_unset() {
+        let (_dir, repo) = make_test_repo();
+        assert!(repo.hooks_path_config().is_none());
+        assert_eq!(repo.effective_hooks_dir(), repo.hooks_dir());
+    }
+
+    #[test]
+    fn test_effective_hooks_dir_honors_relative_hooks_path() {
+        let (_dir, repo) = make_test_repo();
+        run_cmd(
+            &repo.root,
+            "git",
+            &["config", "core.hooksPath", "dev-hooks"],
+        );
+
+        assert_eq!(repo.hooks_path_config().as_deref(), Some("dev-hooks"));
+        assert_eq!(repo.effective_hooks_dir(), repo.root.join("dev-hooks"));
+    }
+
+    #[test]
+    fn test_effective_hooks_dir_honors_absolute_hooks_path() {
+        let (_dir, repo) = make_test_repo();
+        let abs = repo.root.join("custom-hooks");
+        run_cmd(
+            &repo.root,
+            "git",
+            &["config", "core.hooksPath", abs.to_str().unwrap()],
+        );
+
+        assert_eq!(repo.effective_hooks_dir(), abs);
     }
 
     #[test]

--- a/src/git.rs
+++ b/src/git.rs
@@ -124,6 +124,35 @@ impl GitRepo {
         self.common_dir.join("hooks")
     }
 
+    /// Enumerate the working-tree paths of all worktrees attached to this repository.
+    ///
+    /// Uses `git worktree list --porcelain`. If enumeration fails (e.g. Git too old),
+    /// falls back to just this worktree's root so callers keep working.
+    pub fn list_worktree_paths(&self) -> Vec<PathBuf> {
+        let mut paths = Vec::new();
+
+        if let Ok(output) = Command::new("git")
+            .args(["worktree", "list", "--porcelain"])
+            .current_dir(&self.root)
+            .output()
+        {
+            if output.status.success() {
+                let stdout = String::from_utf8_lossy(&output.stdout);
+                for line in stdout.lines() {
+                    if let Some(rest) = line.strip_prefix("worktree ") {
+                        paths.push(PathBuf::from(rest.trim()));
+                    }
+                }
+            }
+        }
+
+        if paths.is_empty() {
+            paths.push(self.root.clone());
+        }
+
+        paths
+    }
+
     /// Get current HEAD commit hash (full)
     pub fn head_commit(&self) -> anyhow::Result<String> {
         let output = self.run_git(&["rev-parse", "HEAD"])?;

--- a/src/hooks/CLAUDE.md
+++ b/src/hooks/CLAUDE.md
@@ -1,6 +1,6 @@
 # src/hooks/
 
-Git hook handlers. These are called via `git-shadow hook <name>` from shell scripts installed in `.git/hooks/`.
+Git hook handlers. These are called via `git-shadow hook <name>` from shell scripts installed in the effective hooks dir (`.git/hooks/`, or `core.hooksPath` when set).
 
 ## Hook Lifecycle
 
@@ -15,6 +15,10 @@ git commit
 git pull / git merge
   -> .git/hooks/post-merge
        -> git-shadow hook post-merge    [post_merge.rs]
+
+git commit --amend / git rebase / git filter-branch
+  -> .git/hooks/post-rewrite
+       -> git-shadow hook post-rewrite  [post_rewrite.rs]
 ```
 
 ## Design Notes
@@ -48,9 +52,9 @@ On any error in step 5-6, `tx.rollback()` restores all stashed files and re-stag
 
 Reads all files from `stash/`, writes them back to the working tree, and releases the lock. Failures are logged but do not abort -- partial restoration is better than losing everything. If any file fails, the lock is kept so `restore` can retry.
 
-### post_merge.rs: Drift Detection
+### post_merge.rs / post_rewrite.rs: Clean-Only Auto-Rebase
 
-After `git pull`/`git merge`, compares stored baseline content with current HEAD content. If they differ, warns the user to run `git-shadow rebase`. This is advisory only -- no modifications are made.
+Both delegate to `rebase::auto_rebase_all(git, trigger)` (post-merge fires after `git pull`/`git merge`; post-rewrite after `git commit --amend`/`git rebase`). `auto_rebase_all` acquires the shadow lock -- if another process holds it (a commit in progress), or it is stale/corrupt, it skips with a warning rather than failing the git operation. Under the lock it 3-way-merges each overlay baseline up to the new HEAD in `RebaseMode::Auto`: clean merges update the baseline and working tree; conflicting ones are **deferred** (no conflict markers written, baseline left untouched) with a warning telling the user to run `git-shadow rebase` manually. Non-overlay entries and baselines already at HEAD are skipped.
 
 ## Critical Invariants
 

--- a/src/hooks/post_commit.rs
+++ b/src/hooks/post_commit.rs
@@ -1,14 +1,50 @@
 use anyhow::Result;
 use colored::Colorize;
 
-use crate::config::ShadowConfig;
 use crate::git::GitRepo;
 use crate::lock;
 use crate::path;
 use crate::ui;
 
+/// Decide whether restoring `stash_content` to `worktree_path` would overwrite edits
+/// the user made after the commit object was written.
+///
+/// Safe to overwrite when the current worktree content is missing, already equal to the
+/// stash content, or still equal to the baseline that pre-commit restored (overlays).
+/// Otherwise the worktree diverged from both and must be preserved.
+fn would_overwrite_edits(
+    git: &GitRepo,
+    normalized: &str,
+    worktree_path: &std::path::Path,
+    stash_content: &[u8],
+) -> bool {
+    let Ok(current) = std::fs::read(worktree_path) else {
+        // Nothing on disk to overwrite.
+        return false;
+    };
+
+    if current == stash_content {
+        // Already matches what we would write.
+        return false;
+    }
+
+    // For overlays, pre-commit leaves the baseline in the worktree; that is the expected
+    // state and is safe to overwrite with the shadow content.
+    let baseline_path = git
+        .shadow_dir
+        .join("baselines")
+        .join(path::encode_path(normalized));
+    if let Ok(baseline) = std::fs::read(&baseline_path) {
+        if current == baseline {
+            return false;
+        }
+    }
+
+    // Current content differs from both the stash and the expected baseline: user edited it.
+    true
+}
+
 pub fn handle(git: &GitRepo) -> Result<()> {
-    let _config = ShadowConfig::load(&git.shadow_dir)?;
     let stash_dir = git.shadow_dir.join("stash");
 
     // If no stash directory or no files, nothing to do (e.g. --no-verify)
@@ -36,26 +72,9 @@ pub fn handle(git: &GitRepo) -> Result<()> {
         let worktree_path = git.root.join(&normalized);
         let stash_path = entry.path();
 
-        // Best-effort restore
-        match std::fs::read(&stash_path) {
-            Ok(content) => match std::fs::write(&worktree_path, &content) {
-                Ok(_) => {
-                    // Successfully restored, remove stash entry
-                    let _ = std::fs::remove_file(&stash_path);
-                }
-                Err(e) => {
-                    eprintln!(
-                        "{}",
-                        ui::post_commit_restore_failed(
-                            ui::detect_locale(),
-                            &normalized,
-                            &e.to_string()
-                        )
-                        .yellow()
-                    );
-                    failed.push(normalized.clone());
-                }
-            },
+        // Read the stashed shadow content first.
+        let content = match std::fs::read(&stash_path) {
+            Ok(content) => content,
             Err(e) => {
                 eprintln!(
                     "{}",
@@ -63,6 +82,56 @@ pub fn handle(git: &GitRepo) -> Result<()> {
                         ui::detect_locale(),
                         &normalized,
                         &e.to_string(),
+                    )
+                    .yellow()
+                );
+                failed.push(normalized.clone());
+                continue;
+            }
+        };
+
+        // Overwrite safety: if the worktree file was edited since pre-commit ran
+        // (e.g. `git commit --no-verify` bypassed the StashRemaining guard), do not
+        // clobber the user's edits. Leave the stash entry in place and warn.
+        if would_overwrite_edits(git, &normalized, &worktree_path, &content) {
+            eprintln!(
+                "{}",
+                ui::post_commit_restore_conflict(ui::detect_locale(), &normalized).yellow()
+            );
+            failed.push(normalized.clone());
+            continue;
+        }
+
+        // Ensure parent directories exist before writing (nested paths).
+        if let Some(parent) = worktree_path.parent() {
+            if let Err(e) = std::fs::create_dir_all(parent) {
+                eprintln!(
+                    "{}",
+                    ui::post_commit_restore_failed(
+                        ui::detect_locale(),
+                        &normalized,
+                        &e.to_string()
+                    )
+                    .yellow()
+                );
+                failed.push(normalized.clone());
+                continue;
+            }
+        }
+
+        // Best-effort restore
+        match std::fs::write(&worktree_path, &content) {
+            Ok(_) => {
+                // Successfully restored, remove stash entry
+                let _ = std::fs::remove_file(&stash_path);
+            }
+            Err(e) => {
+                eprintln!(
+                    "{}",
+                    ui::post_commit_restore_failed(
+                        ui::detect_locale(),
+                        &normalized,
+                        &e.to_string()
                     )
                     .yellow()
                 );
@@ -136,6 +205,11 @@ mod tests {
         // Simulate post pre-commit state: baseline in worktree, shadow in stash
         std::fs::write(git.root.join("CLAUDE.md"), "# Team\n").unwrap();
         fs_util::atomic_write(
+            &git.shadow_dir.join("baselines").join("CLAUDE.md"),
+            b"# Team\n",
+        )
+        .unwrap();
+        fs_util::atomic_write(
             &git.shadow_dir.join("stash").join("CLAUDE.md"),
             b"# Team\n# My shadow\n",
         )
@@ -196,6 +270,86 @@ mod tests {
             lock::check_lock(&git.shadow_dir).unwrap(),
             lock::LockStatus::Free
         ));
+    }
+
+    #[test]
+    fn test_skips_restore_when_worktree_edited_after_commit() {
+        let (_dir, git) = make_test_repo();
+
+        // Baseline is what pre-commit would have restored to the worktree.
+        fs_util::atomic_write(
+            &git.shadow_dir.join("baselines").join("CLAUDE.md"),
+            b"# Team\n",
+        )
+        .unwrap();
+        // Stash holds the original shadow content.
+        fs_util::atomic_write(
+            &git.shadow_dir.join("stash").join("CLAUDE.md"),
+            b"# Team\n# My shadow\n",
+        )
+        .unwrap();
+        // User edited the file after committing (differs from baseline AND stash).
+        std::fs::write(
+            git.root.join("CLAUDE.md"),
+            "# Team\n# User edit after commit\n",
+        )
+        .unwrap();
+        lock::acquire_lock(&git.shadow_dir).unwrap();
+
+        handle(&git).unwrap();
+
+        // User's edit must be preserved.
+        let content = std::fs::read_to_string(git.root.join("CLAUDE.md")).unwrap();
+        assert_eq!(content, "# Team\n# User edit after commit\n");
+
+        // Stash entry must be kept for manual recovery.
+        assert!(git.shadow_dir.join("stash").join("CLAUDE.md").exists());
+
+        // Lock must be kept because restore did not complete cleanly.
+        assert!(!matches!(
+            lock::check_lock(&git.shadow_dir).unwrap(),
+            lock::LockStatus::Free
+        ));
+    }
+
+    #[test]
+    fn test_restores_when_worktree_matches_baseline() {
+        let (_dir, git) = make_test_repo();
+
+        fs_util::atomic_write(
+            &git.shadow_dir.join("baselines").join("CLAUDE.md"),
+            b"# Team\n",
+        )
+        .unwrap();
+        fs_util::atomic_write(
+            &git.shadow_dir.join("stash").join("CLAUDE.md"),
+            b"# Team\n# My shadow\n",
+        )
+        .unwrap();
+        // Worktree still holds the baseline pre-commit restored.
+        std::fs::write(git.root.join("CLAUDE.md"), "# Team\n").unwrap();
+        lock::acquire_lock(&git.shadow_dir).unwrap();
+
+        handle(&git).unwrap();
+
+        let content = std::fs::read_to_string(git.root.join("CLAUDE.md")).unwrap();
+        assert_eq!(content, "# Team\n# My shadow\n");
+        assert!(!git.shadow_dir.join("stash").join("CLAUDE.md").exists());
+    }
+
+    #[test]
+    fn test_creates_parent_dirs_when_restoring_nested_stash() {
+        let (_dir, git) = make_test_repo();
+
+        // Nested stash entry whose parent directory does not exist yet.
+        let encoded = path::encode_path("src/deep/local.md");
+        fs_util::atomic_write(&git.shadow_dir.join("stash").join(&encoded), b"# Nested\n").unwrap();
+        lock::acquire_lock(&git.shadow_dir).unwrap();
+
+        handle(&git).unwrap();
+
+        let content = std::fs::read_to_string(git.root.join("src/deep/local.md")).unwrap();
+        assert_eq!(content, "# Nested\n");
     }
 
     #[test]

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -17,6 +17,8 @@ pub enum LockStatus {
     HeldByUs,
     HeldByOther(LockInfo),
     Stale(LockInfo),
+    /// Lockfile exists but its contents could not be parsed.
+    Corrupt,
 }
 
 /// Check current lock status
@@ -27,7 +29,12 @@ pub fn check_lock(shadow_dir: &Path) -> anyhow::Result<LockStatus> {
     }
 
     let content = std::fs::read_to_string(&lock_path).context("failed to read lockfile")?;
-    let info = parse_lock(&content)?;
+    // A lockfile we cannot parse cannot be attributed to any live process, so
+    // report it as Corrupt rather than propagating an error. Callers can then
+    // decide to reclaim it (e.g. `restore`).
+    let Ok(info) = parse_lock(&content) else {
+        return Ok(LockStatus::Corrupt);
+    };
 
     let my_pid = std::process::id();
     if info.pid == my_pid {
@@ -42,34 +49,54 @@ pub fn check_lock(shadow_dir: &Path) -> anyhow::Result<LockStatus> {
 }
 
 /// Acquire lock (write PID + timestamp). Fails if locked by another live process.
+///
+/// Acquisition is atomic: the lockfile is created with `O_CREAT | O_EXCL`
+/// (`File::create_new`) so two concurrent processes can never both succeed.
+/// If the file already exists we inspect it to classify the holder:
+/// - held by us => `Ok(())` (idempotent)
+/// - held by a live process => `Err(LockHeld)`
+/// - held by a dead process => `Err(StaleLock)`
+/// - unparseable/corrupt => `Err(CorruptLock)`, treated like a stale lock: we do
+///   NOT silently clobber it (that was the previous bug); the user reclaims it via
+///   `git-shadow restore`.
 pub fn acquire_lock(shadow_dir: &Path) -> Result<(), ShadowError> {
     let lock_path = shadow_dir.join("lock");
 
-    if lock_path.exists() {
-        let content = std::fs::read_to_string(&lock_path)?;
-        if let Ok(info) = parse_lock(&content) {
-            let my_pid = std::process::id();
-            if info.pid == my_pid {
-                return Ok(()); // Already held by us
-            }
-            if is_process_alive(info.pid) {
-                return Err(ShadowError::LockHeld {
-                    pid: info.pid,
-                    timestamp: info.timestamp.to_rfc3339(),
-                });
-            }
-            // Stale lock
-            return Err(ShadowError::StaleLock(info.pid));
+    match std::fs::File::create_new(&lock_path) {
+        Ok(mut file) => {
+            use std::io::Write;
+            let content = format!(
+                "pid={}\ntimestamp={}",
+                std::process::id(),
+                Utc::now().to_rfc3339()
+            );
+            file.write_all(content.as_bytes())?;
+            Ok(())
         }
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+            let content = std::fs::read_to_string(&lock_path)?;
+            match parse_lock(&content) {
+                Ok(info) => {
+                    let my_pid = std::process::id();
+                    if info.pid == my_pid {
+                        return Ok(()); // Already held by us
+                    }
+                    if is_process_alive(info.pid) {
+                        return Err(ShadowError::LockHeld {
+                            pid: info.pid,
+                            timestamp: info.timestamp.to_rfc3339(),
+                        });
+                    }
+                    // Stale lock: held by a process that no longer exists.
+                    Err(ShadowError::StaleLock(info.pid))
+                }
+                // Corrupted lock: cannot be attributed to any process. Treat it as
+                // stale but surface a clear, dedicated error instead of overwriting.
+                Err(_) => Err(ShadowError::CorruptLock),
+            }
+        }
+        Err(e) => Err(e.into()),
     }
-
-    let content = format!(
-        "pid={}\ntimestamp={}",
-        std::process::id(),
-        Utc::now().to_rfc3339()
-    );
-    std::fs::write(&lock_path, content)?;
-    Ok(())
 }
 
 /// Release lock (remove file)
@@ -118,6 +145,17 @@ mod tests {
         let shadow_dir = dir.path().join("shadow");
         std::fs::create_dir_all(&shadow_dir).unwrap();
         (dir, shadow_dir)
+    }
+
+    /// Spawn a real, signalable child process so that `is_process_alive` reports
+    /// it as live. (Using PID 1 is unreliable: on macOS `kill(1, 0)` returns
+    /// EPERM, which our existence check treats as "not alive".) Caller must kill
+    /// the returned child.
+    fn spawn_live_process() -> std::process::Child {
+        std::process::Command::new("sleep")
+            .arg("30")
+            .spawn()
+            .expect("failed to spawn helper process")
     }
 
     #[test]
@@ -183,12 +221,64 @@ mod tests {
     #[test]
     fn test_acquire_lock_fails_on_live_other_process() {
         let (_dir, shadow_dir) = make_shadow_dir();
-        // Write a lock with PID 1 (init/launchd - always alive)
+        let mut child = spawn_live_process();
         let lock_path = shadow_dir.join("lock");
-        let content = format!("pid=1\ntimestamp={}", Utc::now().to_rfc3339());
+        let content = format!("pid={}\ntimestamp={}", child.id(), Utc::now().to_rfc3339());
         std::fs::write(&lock_path, content).unwrap();
 
         let result = acquire_lock(&shadow_dir);
+        let is_held = matches!(result, Err(ShadowError::LockHeld { .. }));
+        let _ = child.kill();
+        let _ = child.wait();
+        assert!(is_held, "expected LockHeld for a live process");
+    }
+
+    #[test]
+    fn test_acquire_lock_reports_stale_on_dead_process() {
+        let (_dir, shadow_dir) = make_shadow_dir();
+        let lock_path = shadow_dir.join("lock");
+        let content = format!("pid=999999\ntimestamp={}", Utc::now().to_rfc3339());
+        std::fs::write(&lock_path, content).unwrap();
+
+        let result = acquire_lock(&shadow_dir);
+        assert!(matches!(result, Err(ShadowError::StaleLock(999999))));
+    }
+
+    #[test]
+    fn test_acquire_lock_is_atomic_second_acquire_by_other_fails() {
+        // Simulate a lock already held by another live process, then verify a
+        // fresh acquisition does not overwrite it (atomic create_new).
+        let (_dir, shadow_dir) = make_shadow_dir();
+        let mut child = spawn_live_process();
+        let lock_path = shadow_dir.join("lock");
+        let existing = format!("pid={}\ntimestamp={}", child.id(), Utc::now().to_rfc3339());
+        std::fs::write(&lock_path, &existing).unwrap();
+
+        let result = acquire_lock(&shadow_dir);
+        // The original lock content must be untouched.
+        let after = std::fs::read_to_string(&lock_path).unwrap();
+        let _ = child.kill();
+        let _ = child.wait();
         assert!(result.is_err());
+        assert_eq!(after, existing);
+    }
+
+    #[test]
+    fn test_corrupt_lock_reported_by_check_and_acquire() {
+        let (_dir, shadow_dir) = make_shadow_dir();
+        let lock_path = shadow_dir.join("lock");
+        // Garbage that parse_lock cannot interpret (no pid field).
+        std::fs::write(&lock_path, "this is not a valid lockfile").unwrap();
+
+        assert!(matches!(
+            check_lock(&shadow_dir).unwrap(),
+            LockStatus::Corrupt
+        ));
+        assert!(matches!(
+            acquire_lock(&shadow_dir),
+            Err(ShadowError::CorruptLock)
+        ));
+        // Corrupt lock is not silently clobbered.
+        assert!(lock_path.exists());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ fn run() -> anyhow::Result<()> {
 
     match cli.command {
         Commands::Install => commands::install::run()?,
+        Commands::Uninstall { force } => commands::uninstall::run(force)?,
         Commands::Add {
             files,
             overlay,
@@ -23,13 +24,13 @@ fn run() -> anyhow::Result<()> {
             force,
         } => commands::add::run(&files, overlay, phantom, no_exclude, force)?,
         Commands::Remove { file, force } => commands::remove::run(&file, force)?,
-        Commands::Status { git } => commands::status::run(git)?,
+        Commands::Status { git, json } => commands::status::run(git, json)?,
         Commands::Diff { file } => commands::diff::run(file.as_deref())?,
         Commands::Rebase { file } => commands::rebase::run(file.as_deref())?,
         Commands::Restore { file } => commands::restore::run(file.as_deref())?,
         Commands::Suspend => commands::suspend::run()?,
         Commands::Resume => commands::resume::run()?,
-        Commands::Doctor => commands::doctor::run()?,
+        Commands::Doctor { json } => commands::doctor::run(json)?,
         Commands::Hook { hook_name } => commands::hook::run(&hook_name)?,
     }
 

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -2,7 +2,10 @@ use std::path::Path;
 
 use anyhow::{Context, Result};
 
+use crate::error::ShadowError;
+
 /// Result of a 3-way merge
+#[derive(Debug)]
 pub struct MergeResult {
     /// The merged content
     pub content: String,
@@ -40,29 +43,45 @@ pub fn three_way_merge(
     std::fs::write(ours_file.path(), ours)?;
     std::fs::write(theirs_file.path(), theirs)?;
 
-    // git merge-file modifies ours_file in place and returns:
-    // 0: clean merge
-    // >0: number of conflicts
-    // <0: error
+    run_merge_file(ours_file.path(), base_file.path(), theirs_file.path())
+}
+
+/// Run `git merge-file -p --diff3 <ours> <base> <theirs>` and interpret the result.
+///
+/// `git merge-file` exit codes:
+/// - `0` => clean merge (no conflicts)
+/// - `1..=127` => number of conflicts (capped at 127); merge succeeded with markers
+/// - otherwise => the merge itself failed (git returns a negative value on error, which
+///   surfaces as an exit code in the 128..=255 range), or the process was killed by a
+///   signal (`code()` is `None`). In these cases stdout is unusable (typically empty), so
+///   writing it to the working tree would truncate the user's file. Report an error instead.
+fn run_merge_file(ours: &Path, base: &Path, theirs: &Path) -> Result<MergeResult> {
     let output = std::process::Command::new("git")
         .args([
             "merge-file",
             "-p",      // print to stdout instead of modifying file
             "--diff3", // show base content in conflict markers
         ])
-        .arg(ours_file.path())
-        .arg(base_file.path())
-        .arg(theirs_file.path())
+        .arg(ours)
+        .arg(base)
+        .arg(theirs)
         .output()
         .context("failed to run git merge-file")?;
 
-    let content = String::from_utf8_lossy(&output.stdout).to_string();
-    let has_conflicts = output.status.code().unwrap_or(-1) > 0;
-
-    Ok(MergeResult {
-        content,
-        has_conflicts,
-    })
+    match output.status.code() {
+        Some(0) => Ok(MergeResult {
+            content: String::from_utf8_lossy(&output.stdout).to_string(),
+            has_conflicts: false,
+        }),
+        Some(n) if (1..=127).contains(&n) => Ok(MergeResult {
+            content: String::from_utf8_lossy(&output.stdout).to_string(),
+            has_conflicts: true,
+        }),
+        _ => {
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            Err(ShadowError::MergeFailed(stderr).into())
+        }
+    }
 }
 
 #[cfg(test)]
@@ -127,5 +146,54 @@ mod tests {
         let result = three_way_merge(base, ours, theirs, dir.path()).unwrap();
         assert!(!result.has_conflicts);
         assert!(result.content.contains("their addition"));
+    }
+
+    #[test]
+    fn test_merge_error_is_reported_not_treated_as_conflict() {
+        // Force a real `git merge-file` error by passing a directory as the
+        // `ours` path. On error, git returns a negative value (surfacing as a
+        // high exit code) with empty stdout — this must be an Err, never a
+        // MergeResult with empty content that would truncate the file.
+        let dir = tempfile::tempdir().unwrap();
+        let sub_dir = dir.path().join("is-a-directory");
+        std::fs::create_dir(&sub_dir).unwrap();
+
+        let base = dir.path().join("base");
+        let theirs = dir.path().join("theirs");
+        std::fs::write(&base, "a\n").unwrap();
+        std::fs::write(&theirs, "a\n").unwrap();
+
+        let result = run_merge_file(&sub_dir, &base, &theirs);
+        assert!(result.is_err(), "merge error must surface as Err");
+        let err = result.unwrap_err();
+        assert!(
+            err.downcast_ref::<ShadowError>()
+                .map(|e| matches!(e, ShadowError::MergeFailed(_)))
+                .unwrap_or(false),
+            "error should be ShadowError::MergeFailed, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_run_merge_file_clean_and_conflict() {
+        let dir = tempfile::tempdir().unwrap();
+        // Clean merge
+        let base = dir.path().join("base");
+        let ours = dir.path().join("ours");
+        let theirs = dir.path().join("theirs");
+        std::fs::write(&base, "line1\nline2\n").unwrap();
+        std::fs::write(&ours, "line1\nline2\nline3\n").unwrap();
+        std::fs::write(&theirs, "line1\nline2\n").unwrap();
+        let clean = run_merge_file(&ours, &base, &theirs).unwrap();
+        assert!(!clean.has_conflicts);
+        assert!(clean.content.contains("line3"));
+
+        // Conflicting merge
+        std::fs::write(&base, "line1\n").unwrap();
+        std::fs::write(&ours, "ours\n").unwrap();
+        std::fs::write(&theirs, "theirs\n").unwrap();
+        let conflict = run_merge_file(&ours, &base, &theirs).unwrap();
+        assert!(conflict.has_conflicts);
+        assert!(conflict.content.contains("<<<<<<<"));
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -124,6 +124,41 @@ pub fn install_success(locale: UiLocale) -> &'static str {
     )
 }
 
+pub fn install_custom_hooks_path(locale: UiLocale, hooks_path: &str, resolved: &str) -> String {
+    match locale {
+        UiLocale::Ja => format!(
+            "note: core.hooksPath ({hooks_path}) が設定されているため、hooks を {resolved} にインストールしました"
+        ),
+        UiLocale::En => format!(
+            "note: core.hooksPath ({hooks_path}) is set, so hooks were installed into {resolved}"
+        ),
+    }
+}
+
+pub fn uninstall_success(locale: UiLocale) -> &'static str {
+    choose(
+        locale,
+        "git-shadow を uninstall しました (hooks・exclude・state を削除しました)",
+        "git-shadow uninstalled (hooks, exclude entries, and state removed)",
+    )
+}
+
+pub fn uninstall_hook_restored(locale: UiLocale, hook: &str) -> String {
+    match locale {
+        UiLocale::Ja => format!("{hook} hook の pre-shadow backup を復元しました"),
+        UiLocale::En => format!("restored pre-shadow backup for {hook} hook"),
+    }
+}
+
+pub fn uninstall_forced_overlays(locale: UiLocale, count: usize) -> String {
+    match locale {
+        UiLocale::Ja => {
+            format!("{count} 件の overlay の baseline を working tree に復元しました")
+        }
+        UiLocale::En => format!("restored baselines to the working tree for {count} overlay(s)"),
+    }
+}
+
 pub fn inherited_from_main_worktree(locale: UiLocale, count: usize) -> String {
     match locale {
         UiLocale::Ja => format!("main worktree から {count} 件のファイル設定を引き継ぎました"),
@@ -436,6 +471,17 @@ pub fn doctor_hook_not_executable(locale: UiLocale, hook: &str) -> String {
     match locale {
         UiLocale::Ja => format!("{hook} hook に実行権限がありません"),
         UiLocale::En => format!("{hook} hook is not executable"),
+    }
+}
+
+pub fn doctor_hooks_inert(locale: UiLocale, hooks_path: &str) -> String {
+    match locale {
+        UiLocale::Ja => format!(
+            "hooks は既定の hooks dir にありますが core.hooksPath ({hooks_path}) が別を指しているため実行されません。`git-shadow install` を再実行してください"
+        ),
+        UiLocale::En => format!(
+            "hooks are installed in the default hooks dir but core.hooksPath ({hooks_path}) points elsewhere, so they never run. Re-run `git-shadow install`"
+        ),
     }
 }
 
@@ -859,6 +905,15 @@ fn format_shadow_error_ja(err: &ShadowError) -> String {
             "エラー: hooks が未インストールです。`git-shadow install` を実行してください"
                 .to_string()
         }
+        ShadowError::UninstallHasEntries(count) => format!(
+            "エラー: {count} 件のファイルがまだ git-shadow の管理対象です。\n\
+             対処:\n\
+             1. `git-shadow remove <file>` で個別に解除する\n\
+             2. または `git-shadow uninstall --force` で overlay を復元して state を削除する"
+        ),
+        ShadowError::DoctorFoundIssues(count) => {
+            format!("エラー: doctor が {count} 件の問題を検出しました")
+        }
         ShadowError::NonInteractiveWithoutForce => {
             "エラー: 非対話モードでは `--force` が必要です".to_string()
         }
@@ -987,6 +1042,15 @@ What to do:\n\
         ShadowError::NotSuspended => "Error: shadow changes are not suspended".to_string(),
         ShadowError::HooksNotInstalled => {
             "Error: hooks not installed. Run `git-shadow install`".to_string()
+        }
+        ShadowError::UninstallHasEntries(count) => format!(
+            "Error: {count} file(s) are still managed by git-shadow.\n\
+             What to do:\n\
+             1. Run `git-shadow remove <file>` for each file\n\
+             2. Or run `git-shadow uninstall --force` to restore overlays and wipe state"
+        ),
+        ShadowError::DoctorFoundIssues(count) => {
+            format!("Error: doctor found {count} issue(s)")
         }
         ShadowError::NonInteractiveWithoutForce => {
             "Error: `--force` is required in non-interactive mode".to_string()

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -390,6 +390,17 @@ pub fn post_commit_read_stash_failed(locale: UiLocale, path: &str, error: &str) 
     }
 }
 
+pub fn post_commit_restore_conflict(locale: UiLocale, path: &str) -> String {
+    match locale {
+        UiLocale::Ja => format!(
+            "warning: {path} は commit 後に編集されているため上書きしませんでした。`git-shadow restore` で確認してください"
+        ),
+        UiLocale::En => format!(
+            "warning: {path} was edited after the commit, so it was left untouched. Run `git-shadow restore` to review"
+        ),
+    }
+}
+
 pub fn post_commit_partial_failure(locale: UiLocale) -> &'static str {
     choose(
         locale,
@@ -822,6 +833,13 @@ fn format_shadow_error_ja(err: &ShadowError) -> String {
              2. 必要なら退避してから `git-shadow restore` を実行する\n\
              3. その後で `git commit` をやり直す"
         ),
+        ShadowError::ResumeEditConflict(file) => format!(
+            "resume を止めました: suspend 中に編集された `{file}` を上書きする可能性があります。\n\
+             対処:\n\
+             1. `{file}` の現在内容を確認する\n\
+             2. 残したい内容を退避する\n\
+             3. `.git/shadow/suspended/` の内容と統合してから再度 `git-shadow resume` を実行する"
+        ),
         ShadowError::NotInitialized => "\
 エラー: git-shadow がまだ初期化されていません。\n\
 対処:\n\
@@ -946,6 +964,13 @@ What to do:\n\
              1. Review the current contents of `{file}`\n\
              2. Save anything you need, then run `git-shadow restore`\n\
              3. Run `git commit` again"
+        ),
+        ShadowError::ResumeEditConflict(file) => format!(
+            "Resume blocked: `{file}` was edited in the working tree while suspended, and resume would overwrite it.\n\
+             What to do:\n\
+             1. Review the current contents of `{file}`\n\
+             2. Save anything you want to keep\n\
+             3. Reconcile with `.git/shadow/suspended/`, then run `git-shadow resume` again"
         ),
         ShadowError::NotInitialized => "\
 Error: git-shadow is not initialized yet.\n\

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -354,6 +354,17 @@ pub fn auto_rebase_conflict_warning(locale: UiLocale, path: &str) -> String {
     }
 }
 
+pub fn auto_rebase_skipped_locked(locale: UiLocale, trigger: &str) -> String {
+    match locale {
+        UiLocale::Ja => format!(
+            "warning: {trigger} の自動 rebase をスキップしました (別の git-shadow 処理が lock を保持しています)。必要なら後で `git-shadow rebase` を実行してください"
+        ),
+        UiLocale::En => format!(
+            "warning: skipped {trigger} auto-rebase because another git-shadow process holds the lock. Run `git-shadow rebase` later if needed"
+        ),
+    }
+}
+
 pub fn auto_rebase_failed(locale: UiLocale, path: &str, trigger: &str, error: &str) -> String {
     match locale {
         UiLocale::Ja => {
@@ -794,6 +805,16 @@ fn format_shadow_error_ja(err: &ShadowError) -> String {
              2. `git status` を確認する\n\
              3. もう一度 `git commit` する"
         ),
+        ShadowError::CorruptLock => "\
+コミットを止めました: lockfile が壊れています (内容を解釈できません)。\n\
+対処:\n\
+1. `git-shadow restore` を実行して lock を片付ける\n\
+2. `git status` を確認する\n\
+3. もう一度 `git commit` する"
+            .to_string(),
+        ShadowError::MergeFailed(stderr) => {
+            format!("エラー: 3-way merge に失敗しました:\n{stderr}")
+        }
         ShadowError::AutoRestoreConflict(file) => format!(
             "コミットを止めました: stale lock の自動回復で `{file}` を上書きする可能性があります。\n\
              対処:\n\
@@ -909,6 +930,16 @@ What to do:\n\
              2. Check `git status`\n\
              3. Run `git commit` again"
         ),
+        ShadowError::CorruptLock => "\
+Commit blocked: the lockfile is corrupted (its contents could not be parsed).\n\
+What to do:\n\
+1. Run `git-shadow restore`\n\
+2. Check `git status`\n\
+3. Run `git commit` again"
+            .to_string(),
+        ShadowError::MergeFailed(stderr) => {
+            format!("Error: 3-way merge failed:\n{stderr}")
+        }
         ShadowError::AutoRestoreConflict(file) => format!(
             "Commit blocked: automatic stale-lock recovery would overwrite newer working tree content in `{file}`.\n\
              What to do:\n\

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -7,33 +7,52 @@ Integration and E2E tests. Unit tests live alongside their modules in `src/` via
 | File | Purpose |
 |------|---------|
 | `common/mod.rs` | `TestRepo` helper for creating isolated git repos |
-| `test_commit_cycle.rs` | E2E tests for the full commit lifecycle |
+| `test_commit_cycle.rs` | E2E tests for the full commit lifecycle (hook handlers driven in-process) |
 | `test_worktree.rs` | E2E tests for git worktree support |
+| `test_git_operations.rs` | E2E tests running real `git` commands against the installed hooks |
+| `test_localized_errors.rs` | E2E tests for locale-aware output, `--version`, `--json`, `uninstall` |
 
 ## TestRepo Helper
 
 `common::TestRepo` creates a temporary git repository with:
 - `git init` + user config
-- Helper methods: `create_file()`, `read_file()`, `commit()`, `init_shadow()`, `add_worktree()`
+- Helper methods: `create_file()`, `create_dir()`, `read_file()`, `commit()`, `git_dir()`, `shadow_dir()`, `init_shadow()`, `add_worktree()`
 
-Used by E2E tests to set up realistic scenarios without touching the real filesystem.
+Used by E2E tests to set up realistic scenarios without touching the real filesystem. `test_git_operations.rs` and `test_localized_errors.rs` do not use `TestRepo` -- they build their own repos and shell out to the installed `git-shadow` binary.
 
 ## E2E Tests (test_commit_cycle.rs)
 
-Three scenarios covering the core commit lifecycle:
+Five scenarios covering the core commit lifecycle:
 
 1. **`test_full_overlay_commit_cycle`**: install -> add overlay -> edit -> pre-commit -> commit -> post-commit -> verify (committed content = baseline, working tree = shadow)
 2. **`test_full_phantom_commit_cycle`**: install -> add phantom -> stage -> pre-commit -> commit -> post-commit -> verify (phantom not in commit, restored to working tree)
 3. **`test_pre_commit_rollback_on_error`**: Simulates stash remnant causing pre-commit to fail, verifies shadow content is preserved (not lost during rollback)
+4. **`test_full_phantom_directory_commit_cycle`**: phantom-directory (exclude-only) lifecycle -- verifies the directory stays local and is never committed
+5. **`test_mixed_overlay_and_phantom_directory`**: overlay and phantom directory managed together in one commit cycle
 
 ## E2E Tests (test_worktree.rs)
 
 Four scenarios covering git worktree support:
 
-1. **`test_worktree_discover`**: Creates a worktree, verifies `GitRepo::discover()` resolves correct `root`, `git_dir`, and `common_dir` paths
-2. **`test_worktree_install_shares_hooks`**: Installs hooks from a worktree, verifies hooks are written to `common_dir/hooks/` (shared with main worktree)
-3. **`test_worktree_overlay_commit_cycle`**: Full overlay commit cycle in a worktree -- install, add, edit, pre-commit, commit, post-commit -- verifying per-worktree shadow state isolation
+1. **`test_discover_in_worktree`**: Creates a worktree, verifies `GitRepo::discover()` resolves correct `root`, `git_dir`, and `common_dir` paths
+2. **`test_install_in_worktree`**: Installs hooks from a worktree, verifies hooks land in the effective (shared) hooks dir
+3. **`test_overlay_commit_cycle_in_worktree`**: Full overlay commit cycle in a worktree -- install, add, edit, pre-commit, commit, post-commit -- verifying per-worktree shadow state isolation
 4. **`test_install_inherits_config_from_main_worktree`**: Verifies that `install` in a worktree auto-inherits managed files from the main repo -- overlay baselines are regenerated from worktree HEAD, phantom entries are copied as-is
+
+## E2E Tests (test_git_operations.rs)
+
+Six scenarios that install the real hooks and run real `git` commands (the built binary is put on `PATH`):
+
+1. **`test_amend_keeps_shadow_out_of_commit_and_intact_in_worktree`**: `git commit --amend` keeps shadow out of history and intact in the working tree
+2. **`test_rebase_triggers_post_rewrite_and_preserves_shadow`**: `git rebase` fires post-rewrite and preserves shadow
+3. **`test_merge_triggers_post_merge_and_preserves_shadow`**: `git merge` fires post-merge and preserves shadow
+4. **`test_cherry_pick_does_not_leak_shadow`**: `git cherry-pick` does not leak shadow content into the picked commit
+5. **`test_pathspec_commit_isolates_shadow`**: a pathspec-limited commit still isolates shadow
+6. **`test_commit_blocked_by_live_lock_holder`**: a live lock holder blocks the commit rather than corrupting state
+
+## E2E Tests (test_localized_errors.rs)
+
+Locale-aware output and CLI-surface scenarios, including: English/Japanese error and help/status messages selected from locale env vars, `--version`, `doctor` non-zero exit on issues plus valid English `--json`, valid `status --json`, and `uninstall` removing hooks/state (and refusing with active entries).
 
 ## Testing Patterns
 

--- a/tests/test_git_operations.rs
+++ b/tests/test_git_operations.rs
@@ -1,0 +1,502 @@
+//! E2E integration tests for real git operations that interact with the
+//! shadow hooks (pre-commit / post-commit / post-merge / post-rewrite).
+//!
+//! Unlike `test_commit_cycle.rs`, which drives the hook handlers in-process,
+//! these tests install the real hooks via `git-shadow install` and run real
+//! `git` commands (`commit`, `commit --amend`, `rebase`, `merge`,
+//! `cherry-pick`). The installed hooks invoke `git-shadow` from `PATH`, so all
+//! git commands that can fire a hook are run with the built binary's directory
+//! prepended to `PATH`.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+/// Directory containing the built `git-shadow` binary under test.
+fn bin_dir() -> PathBuf {
+    assert_cmd::cargo::cargo_bin!("git-shadow")
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+/// Build a `PATH` value with `dir` prepended so the installed hooks resolve the
+/// binary under test rather than any system-installed `git-shadow`.
+fn prepend_path(dir: &Path) -> String {
+    let current = std::env::var_os("PATH").unwrap_or_default();
+    let mut paths = vec![dir.to_path_buf()];
+    paths.extend(std::env::split_paths(&current));
+    std::env::join_paths(paths)
+        .unwrap()
+        .to_string_lossy()
+        .into_owned()
+}
+
+/// Run a raw `git` command with the shadow binary on `PATH` (so any hook fires
+/// correctly). Returns the raw `Output` without asserting success.
+fn git(root: &Path, args: &[&str]) -> Output {
+    Command::new("git")
+        .args(args)
+        .current_dir(root)
+        .env("PATH", prepend_path(&bin_dir()))
+        .env("LANG", "en_US.UTF-8")
+        .output()
+        .unwrap()
+}
+
+/// Run a `git` command and assert it succeeded.
+fn git_ok(root: &Path, args: &[&str]) -> Output {
+    let out = git(root, args);
+    assert!(
+        out.status.success(),
+        "git {} failed:\nstdout: {}\nstderr: {}",
+        args.join(" "),
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    out
+}
+
+/// Run a `git-shadow` subcommand and assert it succeeded.
+fn shadow_ok(root: &Path, args: &[&str]) -> Output {
+    let out = Command::new("git-shadow")
+        .args(args)
+        .current_dir(root)
+        .env("PATH", prepend_path(&bin_dir()))
+        .env("LANG", "en_US.UTF-8")
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "git-shadow {} failed:\nstdout: {}\nstderr: {}",
+        args.join(" "),
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    out
+}
+
+/// Run a `git-shadow` subcommand and return the raw `Output`.
+fn shadow(root: &Path, args: &[&str]) -> Output {
+    Command::new("git-shadow")
+        .args(args)
+        .current_dir(root)
+        .env("PATH", prepend_path(&bin_dir()))
+        .env("LANG", "en_US.UTF-8")
+        .output()
+        .unwrap()
+}
+
+fn write(root: &Path, rel: &str, content: &str) {
+    let p = root.join(rel);
+    if let Some(parent) = p.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    std::fs::write(p, content).unwrap();
+}
+
+fn read(root: &Path, rel: &str) -> String {
+    std::fs::read_to_string(root.join(rel)).unwrap()
+}
+
+/// `git show HEAD:<rel>` -> committed content (None if not present in HEAD).
+fn show_head(root: &Path, rel: &str) -> Option<String> {
+    let out = git(root, &["show", &format!("HEAD:{rel}")]);
+    if out.status.success() {
+        Some(String::from_utf8_lossy(&out.stdout).to_string())
+    } else {
+        None
+    }
+}
+
+fn head_hash(root: &Path) -> String {
+    String::from_utf8_lossy(&git_ok(root, &["rev-parse", "HEAD"]).stdout)
+        .trim()
+        .to_string()
+}
+
+/// Number of regular files sitting in `.git/shadow/stash/`.
+fn stash_file_count(root: &Path) -> usize {
+    let stash = root.join(".git/shadow/stash");
+    match std::fs::read_dir(&stash) {
+        Ok(rd) => rd
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_type().map(|t| t.is_file()).unwrap_or(false))
+            .count(),
+        Err(_) => 0,
+    }
+}
+
+/// Read the overlay baseline file for `rel` under `.git/shadow/baselines/`.
+/// `rel` here has no `/`, so no path encoding is needed.
+fn baseline(root: &Path, rel: &str) -> String {
+    std::fs::read_to_string(root.join(".git/shadow/baselines").join(rel)).unwrap()
+}
+
+const BASE: &str = "top\nmid\nbot\n";
+const SHADOW: &str = "top\nmid\nbot\nSHADOW_LOCAL\n";
+
+/// Create a repo with `app.txt` committed at [`BASE`], shadow installed, an
+/// overlay registered on `app.txt`, and an unstaged shadow edit ([`SHADOW`]) in
+/// the working tree. Returns the temp dir; its `path()` is the repo root.
+fn setup_overlay_repo() -> tempfile::TempDir {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+
+    git_ok(root, &["init"]);
+    git_ok(root, &["config", "user.name", "Test User"]);
+    git_ok(root, &["config", "user.email", "test@example.com"]);
+
+    write(root, "app.txt", BASE);
+    git_ok(root, &["add", "app.txt"]);
+    git_ok(root, &["commit", "-m", "init"]);
+    // Normalize the branch name regardless of the host git default.
+    git_ok(root, &["branch", "-M", "main"]);
+
+    shadow_ok(root, &["install"]);
+    shadow_ok(root, &["add", "app.txt"]);
+
+    // Introduce the local-only (shadow) change, unstaged.
+    write(root, "app.txt", SHADOW);
+
+    dir
+}
+
+// ---------------------------------------------------------------------------
+// a) git commit --amend
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_amend_keeps_shadow_out_of_commit_and_intact_in_worktree() {
+    let dir = setup_overlay_repo();
+    let root = dir.path();
+
+    // A normal commit of an unrelated file: shadow is stashed then restored.
+    write(root, "feature.txt", "f1\n");
+    git_ok(root, &["add", "feature.txt"]);
+    git_ok(root, &["commit", "-m", "add feature"]);
+
+    // Sanity: the first commit has the baseline, not the shadow, and the
+    // worktree still carries the shadow change.
+    assert_eq!(show_head(root, "app.txt").as_deref(), Some(BASE));
+    assert_eq!(read(root, "app.txt"), SHADOW);
+    assert_eq!(
+        stash_file_count(root),
+        0,
+        "stash must be clean after commit"
+    );
+
+    // Amend: change the message and add a new staged file.
+    write(root, "extra.txt", "e1\n");
+    git_ok(root, &["add", "extra.txt"]);
+    git_ok(root, &["commit", "--amend", "-m", "add feature (amended)"]);
+
+    // The amended commit must not contain shadow content and must include the
+    // newly staged file.
+    assert_eq!(
+        show_head(root, "app.txt").as_deref(),
+        Some(BASE),
+        "amended commit must contain baseline, not shadow"
+    );
+    assert_eq!(show_head(root, "extra.txt").as_deref(), Some("e1\n"));
+    assert_eq!(show_head(root, "feature.txt").as_deref(), Some("f1\n"));
+
+    // Worktree shadow content survives the amend.
+    assert_eq!(read(root, "app.txt"), SHADOW);
+    assert_eq!(stash_file_count(root), 0, "stash must be clean after amend");
+
+    // Document current baseline-consistency behavior. `commit --amend` fires
+    // post-rewrite, which auto-rebases the overlay baseline_commit onto the new
+    // (amended) HEAD. Because the committed content of app.txt is unchanged
+    // (still the baseline), the auto-rebase succeeds and doctor reports no
+    // issues.
+    let doctor = shadow(root, &["doctor"]);
+    assert!(
+        doctor.status.success(),
+        "doctor should report no issues after amend; stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&doctor.stdout),
+        String::from_utf8_lossy(&doctor.stderr)
+    );
+}
+
+// ---------------------------------------------------------------------------
+// b) real git rebase -> post-rewrite auto-rebases the baseline
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_rebase_triggers_post_rewrite_and_preserves_shadow() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+
+    git_ok(root, &["init"]);
+    git_ok(root, &["config", "user.name", "Test User"]);
+    git_ok(root, &["config", "user.email", "test@example.com"]);
+
+    write(root, "app.txt", BASE);
+    git_ok(root, &["add", "app.txt"]);
+    git_ok(root, &["commit", "-m", "init"]);
+    git_ok(root, &["branch", "-M", "main"]);
+
+    shadow_ok(root, &["install"]);
+
+    // feature: a commit that does NOT touch app.txt.
+    git_ok(root, &["checkout", "-b", "feature"]);
+    write(root, "feature.txt", "f1\n");
+    git_ok(root, &["add", "feature.txt"]);
+    git_ok(root, &["commit", "-m", "feat work"]);
+
+    // main advances with a change to app.txt (upstream change to overlay file).
+    git_ok(root, &["checkout", "main"]);
+    write(root, "app.txt", "TOP_UPSTREAM\nmid\nbot\n");
+    git_ok(root, &["add", "app.txt"]);
+    git_ok(root, &["commit", "-m", "upstream change to app.txt"]);
+
+    // Register the overlay on feature and add a shadow edit at the end of the
+    // file (a region disjoint from the upstream change so autostash pops cleanly).
+    git_ok(root, &["checkout", "feature"]);
+    shadow_ok(root, &["add", "app.txt"]);
+    write(root, "app.txt", SHADOW);
+
+    // Rebase feature onto main. The overlay makes the worktree dirty, so use
+    // --autostash (the realistic way to rebase with active shadow changes).
+    let out = git(root, &["rebase", "--autostash", "main"]);
+    assert!(
+        out.status.success(),
+        "rebase --autostash should succeed:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // post-rewrite ran: the baseline was auto-rebased to include the upstream
+    // change to app.txt.
+    assert!(
+        baseline(root, "app.txt").contains("TOP_UPSTREAM"),
+        "baseline should have been auto-rebased to the upstream content; got: {:?}",
+        baseline(root, "app.txt")
+    );
+
+    // Shadow change survived in the worktree, layered on top of the new base.
+    let wt = read(root, "app.txt");
+    assert!(
+        wt.contains("TOP_UPSTREAM"),
+        "worktree should have upstream change: {wt:?}"
+    );
+    assert!(
+        wt.contains("SHADOW_LOCAL"),
+        "worktree should still carry shadow: {wt:?}"
+    );
+
+    assert_eq!(stash_file_count(root), 0, "shadow stash must be clean");
+}
+
+// ---------------------------------------------------------------------------
+// c) real git merge -> post-merge auto-rebases the baseline (clean case)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_merge_triggers_post_merge_and_preserves_shadow() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+
+    git_ok(root, &["init"]);
+    git_ok(root, &["config", "user.name", "Test User"]);
+    git_ok(root, &["config", "user.email", "test@example.com"]);
+
+    write(root, "app.txt", BASE);
+    write(root, "side.txt", "s0\n");
+    git_ok(root, &["add", "app.txt", "side.txt"]);
+    git_ok(root, &["commit", "-m", "init"]);
+    git_ok(root, &["branch", "-M", "main"]);
+
+    shadow_ok(root, &["install"]);
+
+    // other: change app.txt (the overlay's underlying file).
+    git_ok(root, &["checkout", "-b", "other"]);
+    write(root, "app.txt", "TOP_MERGE\nmid\nbot\n");
+    git_ok(root, &["add", "app.txt"]);
+    git_ok(root, &["commit", "-m", "other changes app.txt"]);
+
+    // main diverges by touching a different file, forcing a real merge commit.
+    git_ok(root, &["checkout", "main"]);
+    write(root, "side.txt", "s1\n");
+    git_ok(root, &["add", "side.txt"]);
+    git_ok(root, &["commit", "-m", "main changes side.txt"]);
+
+    // Register the overlay and add a shadow edit at the file's end.
+    shadow_ok(root, &["add", "app.txt"]);
+    write(root, "app.txt", SHADOW);
+
+    // Merge `other`. The overlay makes the worktree dirty, so enable
+    // merge.autoStash (the realistic way to merge with active shadow changes).
+    git_ok(root, &["config", "merge.autoStash", "true"]);
+    let out = git(root, &["merge", "--no-edit", "other"]);
+    assert!(
+        out.status.success(),
+        "merge should succeed:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // post-merge ran: baseline auto-rebased to the merged app.txt content.
+    assert!(
+        baseline(root, "app.txt").contains("TOP_MERGE"),
+        "baseline should have been auto-rebased to the merged content; got: {:?}",
+        baseline(root, "app.txt")
+    );
+
+    // Shadow change survived on top of the merged base.
+    let wt = read(root, "app.txt");
+    assert!(
+        wt.contains("TOP_MERGE"),
+        "worktree should have merged change: {wt:?}"
+    );
+    assert!(
+        wt.contains("SHADOW_LOCAL"),
+        "worktree should still carry shadow: {wt:?}"
+    );
+
+    assert_eq!(stash_file_count(root), 0, "shadow stash must be clean");
+}
+
+// ---------------------------------------------------------------------------
+// d) git cherry-pick
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_cherry_pick_does_not_leak_shadow() {
+    let dir = setup_overlay_repo();
+    let root = dir.path();
+
+    // Create a commit on a side branch that adds a new file only.
+    git_ok(root, &["checkout", "-b", "donor"]);
+    // Reset the working tree to baseline first is unnecessary: the shadow edit
+    // is unstaged and does not block a new-file commit on the donor branch.
+    write(root, "payload.txt", "payload\n");
+    git_ok(root, &["add", "payload.txt"]);
+    git_ok(root, &["commit", "-m", "add payload"]);
+    let donor = head_hash(root);
+
+    // Back on main, remove the payload from the worktree state that the donor
+    // branch introduced (checkout back to main drops payload.txt).
+    git_ok(root, &["checkout", "main"]);
+    // Re-assert the shadow edit (branch checkout preserves it as it is unstaged,
+    // but be explicit for clarity).
+    write(root, "app.txt", SHADOW);
+
+    let out = git(root, &["cherry-pick", &donor]);
+    assert!(
+        out.status.success(),
+        "cherry-pick should succeed:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // The picked commit brought in payload.txt but must not contain shadow
+    // content for app.txt.
+    assert_eq!(show_head(root, "payload.txt").as_deref(), Some("payload\n"));
+    assert_eq!(
+        show_head(root, "app.txt").as_deref(),
+        Some(BASE),
+        "cherry-picked commit must not contain shadow content for app.txt"
+    );
+
+    // Worktree shadow content is intact.
+    assert_eq!(read(root, "app.txt"), SHADOW);
+    assert_eq!(stash_file_count(root), 0, "shadow stash must be clean");
+}
+
+// ---------------------------------------------------------------------------
+// e) partial commit with pathspec: git commit -- <other-file>
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_pathspec_commit_isolates_shadow() {
+    let dir = setup_overlay_repo();
+    let root = dir.path();
+
+    // A second tracked file with an unstaged change.
+    write(root, "b.txt", "b1\n");
+    git_ok(root, &["add", "b.txt"]);
+    git_ok(root, &["commit", "-m", "add b"]);
+    // Shadow edit on app.txt survives the commit; re-assert for clarity.
+    write(root, "app.txt", SHADOW);
+    write(root, "b.txt", "b1\nb2\n");
+
+    // Commit only b.txt via pathspec. This uses a temporary index
+    // (GIT_INDEX_FILE) that the pre-commit hook must cope with.
+    let out = git(root, &["commit", "-m", "update b only", "--", "b.txt"]);
+    assert!(
+        out.status.success(),
+        "pathspec commit should succeed:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // The commit contains only b.txt's change.
+    assert_eq!(show_head(root, "b.txt").as_deref(), Some("b1\nb2\n"));
+    // No shadow content of app.txt leaked into the commit.
+    assert_eq!(
+        show_head(root, "app.txt").as_deref(),
+        Some(BASE),
+        "pathspec commit must not contain shadow content for app.txt"
+    );
+
+    // app.txt shadow content is restored in the worktree.
+    assert_eq!(
+        read(root, "app.txt"),
+        SHADOW,
+        "app.txt shadow content must be restored after pathspec commit"
+    );
+    assert_eq!(stash_file_count(root), 0, "shadow stash must be clean");
+}
+
+// ---------------------------------------------------------------------------
+// f) concurrent commit lock contention
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_commit_blocked_by_live_lock_holder() {
+    let dir = setup_overlay_repo();
+    let root = dir.path();
+
+    // Something to commit so the commit is not rejected for being empty.
+    write(root, "c.txt", "c1\n");
+    git_ok(root, &["add", "c.txt"]);
+
+    // Simulate a concurrent git-shadow process holding the lock: write a lock
+    // file pointing at a live child process.
+    let mut child = Command::new("sleep").arg("30").spawn().unwrap();
+    let lock_path = root.join(".git/shadow/lock");
+    std::fs::write(
+        &lock_path,
+        format!("pid={}\ntimestamp=2026-01-01T00:00:00+00:00", child.id()),
+    )
+    .unwrap();
+
+    let out = git(root, &["commit", "-m", "should be blocked"]);
+    let blocked = !out.status.success();
+
+    // Clean up the helper process before asserting.
+    let _ = child.kill();
+    let _ = child.wait();
+
+    assert!(
+        blocked,
+        "commit must be blocked while the lock is held by a live process;\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // HEAD unchanged (the blocked commit was not created): still "init".
+    let subject = String::from_utf8_lossy(&git_ok(root, &["log", "-1", "--format=%s"]).stdout)
+        .trim()
+        .to_string();
+    assert_eq!(subject, "init", "no new commit should have been created");
+
+    // Worktree shadow intact and no orphaned stash entry.
+    assert_eq!(read(root, "app.txt"), SHADOW, "shadow must be intact");
+    assert_eq!(
+        stash_file_count(root),
+        0,
+        "no stash entry should be orphaned by the blocked commit"
+    );
+}

--- a/tests/test_localized_errors.rs
+++ b/tests/test_localized_errors.rs
@@ -119,6 +119,122 @@ fn test_help_is_japanese_for_japanese_locale() {
 }
 
 #[test]
+fn test_version_flag_prints_version() {
+    let repo = init_repo();
+    let bin = assert_cmd::cargo::cargo_bin!("git-shadow");
+    let bin_dir = bin.parent().unwrap();
+
+    let output = run_git_shadow(repo.path(), bin_dir, "en_US.UTF-8", &["--version"]);
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains(env!("CARGO_PKG_VERSION")),
+        "version output should contain the crate version, got: {stdout}"
+    );
+}
+
+#[test]
+fn test_doctor_exits_nonzero_when_issues() {
+    let repo = init_repo();
+    let bin = assert_cmd::cargo::cargo_bin!("git-shadow");
+    let bin_dir = bin.parent().unwrap();
+
+    // No install => hooks are missing => doctor reports issues => non-zero exit.
+    let output = run_git_shadow(repo.path(), bin_dir, "en_US.UTF-8", &["doctor"]);
+    assert!(
+        !output.status.success(),
+        "doctor should exit non-zero when issues are present"
+    );
+}
+
+#[test]
+fn test_doctor_json_is_valid_and_english() {
+    let repo = init_repo();
+    let bin = assert_cmd::cargo::cargo_bin!("git-shadow");
+    let bin_dir = bin.parent().unwrap();
+
+    // Even under a Japanese locale, --json must stay English/stable.
+    let output = run_git_shadow(repo.path(), bin_dir, "ja_JP.UTF-8", &["doctor", "--json"]);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let value: serde_json::Value = serde_json::from_str(&stdout).expect("doctor --json valid JSON");
+    assert!(value.get("ok").is_some());
+    assert!(value.get("issues").is_some());
+    assert!(value.get("warnings").is_some());
+}
+
+#[test]
+fn test_status_json_is_valid() {
+    let repo = init_repo();
+    let bin = assert_cmd::cargo::cargo_bin!("git-shadow");
+    let bin_dir = bin.parent().unwrap();
+
+    let install = run_git_shadow(repo.path(), bin_dir, "en_US.UTF-8", &["install"]);
+    assert!(install.status.success());
+    let add = run_git_shadow(repo.path(), bin_dir, "en_US.UTF-8", &["add", "tracked.txt"]);
+    assert!(add.status.success());
+
+    let output = run_git_shadow(repo.path(), bin_dir, "en_US.UTF-8", &["status", "--json"]);
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let value: serde_json::Value = serde_json::from_str(&stdout).expect("status --json valid JSON");
+    assert_eq!(value["suspended"], false);
+    assert_eq!(value["files"][0]["path"], "tracked.txt");
+    assert_eq!(value["files"][0]["type"], "overlay");
+}
+
+#[test]
+fn test_uninstall_removes_hooks_and_state() {
+    let repo = init_repo();
+    let bin = assert_cmd::cargo::cargo_bin!("git-shadow");
+    let bin_dir = bin.parent().unwrap();
+
+    let install = run_git_shadow(repo.path(), bin_dir, "en_US.UTF-8", &["install"]);
+    assert!(install.status.success());
+
+    // No managed files => clean uninstall succeeds.
+    let output = run_git_shadow(repo.path(), bin_dir, "en_US.UTF-8", &["uninstall"]);
+    assert!(output.status.success());
+
+    let hooks = Command::new("git")
+        .args(["rev-parse", "--git-path", "hooks"])
+        .current_dir(repo.path())
+        .output()
+        .unwrap();
+    let hooks_dir = repo
+        .path()
+        .join(String::from_utf8_lossy(&hooks.stdout).trim());
+    assert!(!hooks_dir.join("pre-commit").exists());
+}
+
+#[test]
+fn test_uninstall_refuses_with_active_entries() {
+    let repo = init_repo();
+    let bin = assert_cmd::cargo::cargo_bin!("git-shadow");
+    let bin_dir = bin.parent().unwrap();
+
+    let install = run_git_shadow(repo.path(), bin_dir, "en_US.UTF-8", &["install"]);
+    assert!(install.status.success());
+    let add = run_git_shadow(repo.path(), bin_dir, "en_US.UTF-8", &["add", "tracked.txt"]);
+    assert!(add.status.success());
+
+    let output = run_git_shadow(repo.path(), bin_dir, "en_US.UTF-8", &["uninstall"]);
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("still managed"));
+
+    // --force restores the overlay and wipes state.
+    let forced = run_git_shadow(
+        repo.path(),
+        bin_dir,
+        "en_US.UTF-8",
+        &["uninstall", "--force"],
+    );
+    assert!(forced.status.success());
+}
+
+#[test]
 fn test_status_is_english_for_english_locale() {
     let repo = init_repo();
     let bin = assert_cmd::cargo::cargo_bin!("git-shadow");

--- a/tests/test_localized_errors.rs
+++ b/tests/test_localized_errors.rs
@@ -36,13 +36,22 @@ fn run_git_shadow(
     args: &[&str],
 ) -> std::process::Output {
     let path = prepend_path(bin_dir);
-    Command::new("git-shadow")
-        .args(args)
-        .current_dir(root)
-        .env("PATH", path)
-        .env("LANG", locale)
-        .output()
-        .unwrap()
+    let mut cmd = Command::new("git-shadow");
+    cmd.args(args).current_dir(root).env("PATH", path);
+    apply_locale(&mut cmd, locale);
+    cmd.output().unwrap()
+}
+
+/// Pin the process locale hermetically. `detect_locale()` reads
+/// `LC_ALL` > `LC_MESSAGES` > `LANG`, so setting only `LANG` is not enough:
+/// a runner that exports `LC_ALL`/`LC_MESSAGES` (macOS GitHub runners do)
+/// would win and flip the detected locale. Clearing the higher-priority vars
+/// and setting all three to the requested locale makes these assertions
+/// independent of the ambient environment.
+fn apply_locale(cmd: &mut Command, locale: &str) {
+    cmd.env("LC_ALL", locale)
+        .env("LC_MESSAGES", locale)
+        .env("LANG", locale);
 }
 
 fn prepend_path(bin_dir: &Path) -> String {
@@ -89,13 +98,13 @@ fn test_partial_stage_message_is_japanese_for_japanese_locale() {
     )
     .unwrap();
 
-    let output = Command::new("git")
+    let mut commit = Command::new("git");
+    commit
         .args(["commit", "-m", "partial"])
         .current_dir(repo.path())
-        .env("PATH", prepend_path(bin_dir))
-        .env("LANG", "ja_JP.UTF-8")
-        .output()
-        .unwrap();
+        .env("PATH", prepend_path(bin_dir));
+    apply_locale(&mut commit, "ja_JP.UTF-8");
+    let output = commit.output().unwrap();
 
     assert!(!output.status.success());
 


### PR DESCRIPTION
## 概要

コードレビューで洗い出した最優先・中優先の改善点を一括で対応する batch PR です(低優先項目は #14〜#19 に issue 化済み)。9コミットで、堅牢性修正 → 機能追加 → CI/テスト強化 → ドキュメント同期の順に積んでいます。

## 堅牢性修正

- **merge.rs**: `git merge-file` のエラーと conflict を区別。従来はエラー時の空 stdout がマージ結果として worktree に書き込まれ、ファイルが空になり得た
- **lock.rs**: lock 取得を `File::create_new`(O_CREAT|O_EXCL)でアトミック化。破損 lock は `LockStatus::Corrupt` として明示的に扱う
- **restore**: 生存プロセスが保持する lock を破壊しないよう拒否
- **auto_rebase_all**(post-merge/post-rewrite): shadow lock 取得下で実行。取得できない場合は git 操作を失敗させず警告してスキップ
- **post_commit**: stash 復元前に worktree 内容を検証し、`--no-verify` 後のユーザー編集を stash で上書きしない
- **add**: baseline 書き込みを重複チェックの後に移動(管理中ファイルの再 add で baseline が壊れる問題を修正)
- **exclude**: パターンを `/` でアンカーし gitignore 特殊文字をエスケープ(ルート直下 phantom が任意の深さの同名ファイルを隠す問題を修正)。既存の未アンカーエントリはセクション再生成時に自動移行
- **remove**: 他の worktree が参照する exclude エントリを保持
- **suspend/resume**: 途中失敗時のロールバック追加、suspend 中の編集を resume が黙って上書きしない

## 機能追加

- **core.hooksPath 対応**: install はフックを実効フックディレクトリに配置、doctor は不活性フック(hooksPath により実行されないフック)を検出。husky/lefthook 環境や `core.hooksPath dev-hooks` 設定下で shadow 変更が漏洩する問題への対応
- **`uninstall` コマンド**: フック撤去(`.pre-shadow` 復元含む)+ exclude セクション整理 + 状態削除。管理中エントリがある場合は `--force` 必須
- **`--version`** フラグ
- **`doctor`** が issue 検出時に非ゼロ exit(警告のみは 0)
- **`--json`** を status / doctor に追加(英語固定・機械可読)

## CI / テスト

- release.yml にテストゲート(`needs: test`)を追加
- CI の test ジョブを ubuntu + macOS マトリクス化(配布 OS と検証 OS の不一致を解消)
- 実バイナリ+実フック経由の E2E を新設(`tests/test_git_operations.rs`): amend / 実 rebase / 実 merge / cherry-pick / pathspec 部分 commit / 生存 lock による commit ブロック。全シナリオで既存実装の安全性を確認(バグ発覚なし)

## ドキュメント

- usage(EN/JA): フック一覧を4本に修正、add の複数パス・自動判定を反映、uninstall / troubleshooting セクション新設、--json 例を実出力から採取
- requirements.md を v5 に改訂(suspend/resume・自動 rebase・post-rewrite の実装乖離を解消、改訂履歴追加)
- README(EN/JA): Concepts に phantom dir 追加、コマンド表更新
- CLAUDE.md 系(ルート/src/commands/hooks/tests)を現行コードに同期

## 検証

- `cargo fmt --check` / `cargo clippy -- -D warnings`: クリーン
- `cargo test`: 263件全通過(ユニット238 + E2E 25)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added uninstall support, JSON output for status/diagnostics, and version reporting.
  * Added suspend/resume and improved handling for local-only “phantom” directories.
  * Hooks now respect custom Git hook paths and worktree-specific setups.

* **Bug Fixes**
  * Prevented accidental overwrites during restore, resume, and post-commit recovery.
  * Improved lock handling to better avoid conflicts and stale state issues.
  * Made auto-rebase safer during merges and rewrites.

* **Documentation**
  * Expanded the README and usage guides with new commands, options, and workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->