### PR TITLE
feat: add export/import commands for machine migration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,9 +42,12 @@ src/
   exclude.rs           # .git/info/exclude section management
   diff_util.rs         # Unified diff formatting (similar crate)
   merge.rs             # 3-way merge via `git merge-file -p --diff3`
+  archive.rs           # export/import archive format (tar.gz + manifest.json)
   commands/
     install.rs         # Set up hooks + .git/shadow/ structure
     uninstall.rs       # Remove hooks + shadow state (refuses with active entries unless --force)
+    export.rs          # Bundle managed state into a portable archive
+    import.rs          # Restore managed state from an archive (3-way merge, safe-by-default)
     add.rs             # Register overlay or phantom
     remove.rs          # Unregister with confirmation prompt
     status.rs          # Show managed files, warnings (--json)
@@ -66,6 +69,7 @@ tests/
   test_worktree.rs        # E2E: worktree discovery, install, commit cycle, config inheritance
   test_git_operations.rs  # E2E: amend, rebase, merge, cherry-pick, pathspec, live-lock
   test_localized_errors.rs # E2E: locale-aware messages, --version, --json, uninstall
+  test_export_import.rs   # E2E: export/import roundtrip, merge, conflict, binary, idempotency
 ```
 
 ### Path Encoding

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -226,6 +232,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "dialoguer"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -267,10 +282,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "float-cmp"
@@ -303,12 +338,14 @@ dependencies = [
  "clap",
  "colored",
  "dialoguer",
+ "flate2",
  "is-terminal",
  "libc",
  "predicates",
  "serde",
  "serde_json",
  "similar",
+ "tar",
  "tempfile",
  "thiserror 2.0.18",
 ]
@@ -411,6 +448,16 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "normalize-line-endings"
@@ -597,6 +644,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -617,6 +670,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -905,6 +969,16 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
 
 [[package]]
 name = "zeroize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,8 @@ dialoguer = "0.11"
 colored = "2"
 libc = "0.2"
 is-terminal = "0.4"
+tar = "0.4"
+flate2 = "1"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/README.ja.md
+++ b/README.ja.md
@@ -83,6 +83,8 @@ git show HEAD:docker-compose.yml  # クリーンなチーム用の内容のみ
 | `git-shadow restore [file]` | 中断されたコミットやクラッシュからの復旧 |
 | `git-shadow suspend` | ブランチ切替のために shadow 変更を一時退避 |
 | `git-shadow resume` | 退避した shadow 変更を復元（必要に応じて 3-way merge） |
+| `git-shadow export [path] [--force]` | 管理中の state をポータブルな archive にまとめて別マシンへ移行 |
+| `git-shadow import <archive> [--force]` | 新しく clone したリポジトリに archive から state を復元（3-way merge・デフォルト安全側） |
 | `git-shadow doctor [--json]` | hooks・設定の整合性・残留状態を診断。問題があれば非ゼロで終了。`--json` は安定した英語 JSON を出力 |
 
 `git-shadow --version` でインストール済みのバージョンを表示します。

--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ git show HEAD:docker-compose.yml  # clean, team-only content
 | `git-shadow restore [file]` | Recover from interrupted commits or crashes |
 | `git-shadow suspend` | Suspend shadow changes for branch switching |
 | `git-shadow resume` | Resume suspended shadow changes (with 3-way merge if needed) |
+| `git-shadow export [path] [--force]` | Bundle managed state into a portable archive for moving to a new machine |
+| `git-shadow import <archive> [--force]` | Restore managed state from an archive into a freshly cloned repo (3-way merge, safe-by-default) |
 | `git-shadow doctor [--json]` | Diagnose hooks, config integrity, and stale state; exits non-zero when issues are found; `--json` emits stable English JSON |
 
 `git-shadow --version` prints the installed version.

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -330,6 +330,39 @@ git-shadow resume
 3. suspend 中にワーキングツリーで編集されたファイルは、上書きを避けるため resume を拒否する（`.git/shadow/suspended/` の内容と統合してから再実行する）。
 4. `suspended/` をクリーンアップし、`config.suspended = false` にする。
 
+### `git-shadow export`
+
+shadow の state を、別マシンへ移行できるポータブルな archive にまとめる。`.git/shadow/` と `.git/info/exclude` は `git clone` で引き継がれないため、新しく clone したリポジトリへローカル専用の設定を移すためのコマンド。
+
+```bash
+git-shadow export                       # 既定: ./git-shadow-export.tar.gz
+git-shadow export <output-path>
+git-shadow export --force <output-path> # 既存ファイルを上書き
+```
+
+- 出力形式: gzip 圧縮 tar (`.tar.gz`)。`manifest.json`（`format_version`, ツールバージョン, エントリごとのメタデータ）と、管理対象ごとの内容ファイル（`overlay/` = shadow 内容, `baseline/` = ベースライン, `phantom/`, `phantomdir/`）を含む。パス区切りは `path::encode_path` でエンコードしフラットに格納する。内容はバイナリ安全（バイト列としてそのまま保存）。
+- overlay は shadow 内容とベースライン（および baseline_commit）の両方を格納し、import 時の 3-way merge を可能にする。phantom directory は配下の全ファイルを再帰的に格納する。
+- ガード: 管理対象が無い / suspend 中 / commit 処理の途中（stash 残骸・ライブロック）の場合は拒否する。出力先が既に存在する場合は `--force` なしでは上書きしない。
+
+### `git-shadow import`
+
+archive から shadow の state を復元する。新しいマシンで clone → `git-shadow install` の後に実行する。デフォルトで安全側に動作し、問題があっても続行して最後に「imported N, skipped M」を報告する。
+
+```bash
+git-shadow import <archive-path>
+git-shadow import --force <archive-path>
+```
+
+処理フロー:
+
+1. `git-shadow install` 済みであることを要求（未初期化なら install を案内）。suspend 中 / commit 処理の途中では拒否する。`manifest` の `format_version` を検証し、未知バージョンは明確なエラーにする。
+2. phantom（ファイル / ディレクトリ）: 対象パスが無い、または内容が同一なら書き込んで登録（冪等）。異なる内容で既存の場合はスキップして報告する（`--force` で上書き）。
+3. overlay: 対象は HEAD に追跡されている必要がある（無ければスキップ）。ベースラインは現在の HEAD から再生成する。HEAD が archive のベースラインと一致すれば shadow 内容をそのまま、異なれば 3-way merge（archive のベースライン / archive の shadow / 現在の HEAD）で再適用する。クリーンなら書き込み、コンフリクトはマーカーを書かずにスキップする（`--force` で shadow を優先）。
+4. phantom の登録と `.git/info/exclude` 更新は `add` の仕組み（`exclude::union_patterns` + `ExcludeManager::set_entries`）を再利用する。
+5. スキップが 1 件でもあれば非ゼロで終了する。
+
+> ディスク全体の移行や `.git` ごとのコピーでは shadow 状態もそのまま移るため、export/import は不要。
+
 ## 内部データ構造
 
 ### 保存先
@@ -579,5 +612,5 @@ git worktree 環境でも正常に動作する。
 
 | バージョン | 主な変更点 |
 |---|---|
-| v5 | 実装に合わせて仕様を同期: `git-shadow suspend` / `resume` を追加、post-merge / post-rewrite でのクリーン時限定 自動 rebase を明記（旧「自動 rebase は行わない」を更新）、post-rewrite hook を追加、`git-shadow uninstall` を追加、`core.hooksPath` 対応、doctor の非ゼロ終了コードと inert hooks 検出、status / doctor の `--json` 出力を追記。 |
+| v5 | 実装に合わせて仕様を同期: `git-shadow suspend` / `resume` を追加、post-merge / post-rewrite でのクリーン時限定 自動 rebase を明記（旧「自動 rebase は行わない」を更新）、post-rewrite hook を追加、`git-shadow uninstall` を追加、`core.hooksPath` 対応、doctor の非ゼロ終了コードと inert hooks 検出、status / doctor の `--json` 出力を追記。別マシン移行のための `git-shadow export` / `import`（tar.gz + manifest.json、overlay は 3-way merge で再適用、デフォルト安全側）を追加。 |
 | v4 | git worktree 対応（per-worktree state と共有 hooks/exclude、install 時の自動継承）。 |

--- a/docs/usage.ja.md
+++ b/docs/usage.ja.md
@@ -286,8 +286,61 @@ git-shadow resume          # shadow 変更を復元
 
 - `git commit` はブロックされます（pre-commit hook がエラーを返す）
 - `git-shadow diff` と `git-shadow rebase` はブロックされます
+- `git-shadow export` はブロックされます（先に resume すれば archive に shadow の内容が入ります）
 - `git-shadow status` は "SUSPENDED" 状態を表示します
 - `git-shadow doctor` は suspended 状態を警告として報告します
+
+## 新しいマシンへの移行
+
+shadow の state は `.git/shadow/` と `.git/info/exclude` に保存されるため、`git clone` では引き継がれません。別マシンで新しく clone したリポジトリにローカル専用の設定を移すには、`export` / `import` を使います。
+
+> ディスク全体を移行する（あるいは `.git` ディレクトリごとコピーする）場合は、shadow の state もそのまま付いてくるため export/import は不要です。`export` / `import` は「新しく clone した」よくあるケース向けです。
+
+### Export
+
+```bash
+# 管理中の state をポータブルな archive にまとめる
+git-shadow export
+
+# → exported 2 managed file(s) to `/path/to/git-shadow-export.tar.gz`
+
+# 出力先を明示することもできる
+git-shadow export ~/backups/shadow.tar.gz
+
+# 既存の archive を上書きする
+git-shadow export --force ~/backups/shadow.tar.gz
+```
+
+archive は gzip 圧縮された tar (`.tar.gz`) で、`manifest.json`（`format_version`・ツールバージョン）と管理対象ごとの内容ファイルを含みます。含まれる内容:
+
+- **overlay** — 現在の working tree（shadow）の内容 **と** 保存済み baseline **と** baseline commit。移行先リポジトリが先に進んでいた場合に `import` が 3-way merge できるようにするためです。
+- **phantom file** — ファイルの内容。
+- **phantom directory** — 配下の全ファイル（再帰的）。
+
+バイナリ内容は生バイトとして保存され、バイト単位で完全に往復します。export は、管理対象が無いとき・suspend 中（先に `git-shadow resume`）・commit 処理の途中（stash 残骸 / ライブロック）には実行を拒否します。既定の出力先はカレントディレクトリの `git-shadow-export.tar.gz` で、既存ファイルは `--force` なしでは上書きしません。
+
+### Import
+
+新しいマシンでリポジトリを clone し、`git-shadow install` を実行してから import します:
+
+```bash
+git clone <repo-url> myrepo
+cd myrepo
+git-shadow install
+git-shadow import /path/to/git-shadow-export.tar.gz
+
+# → config.txt: imported overlay
+#   notes.md: imported phantom
+#   import finished: 2 imported, 0 skipped
+```
+
+import は **デフォルトで安全側** に動作し、問題があっても続行して最後に集計を報告します:
+
+- **phantom file / directory** — パスが存在しない、または既存でも内容が同一（冪等）なら書き込んで登録します。**異なる**内容で既に存在する場合は、ファイルごとのメッセージを出してスキップし、コマンドは非ゼロで終了します。`--force` を付けると上書きします。
+- **overlay** — 対象は HEAD に追跡されている必要があります（そうでなければスキップ: リポジトリが export 元と一致しません）。baseline は現在の HEAD から再生成します。HEAD が archive 内の baseline と一致すれば shadow の内容をそのまま書き込み、異なれば 3-way merge（archive の baseline / archive の shadow / 現在の HEAD）で shadow の変更を upstream の上に再適用します。クリーンな merge は書き込み、**conflict** はスキップ（conflict marker は書き込みません）してコマンドは非ゼロ終了します。`--force` を付けると、衝突する upstream の hunk を捨てて shadow を優先します。
+- **管理済みエントリ** — 同一内容の再 import は no-op。別の種類として管理されているエントリは、`--force` で置き換える場合を除きスキップします。
+
+import は conflict を越えて続行するため、**解消してから再実行**すれば（衝突するローカル変更を消す、または `--force` を付ける）残りのエントリを処理できます。import は先に `git-shadow install` が必要で、suspend 中や commit 処理の途中では拒否します。また manifest の `format_version` を検証し、未知のバージョンには明確なエラーを返します。
 
 ## リカバリ
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -286,8 +286,61 @@ git-shadow resume          # shadow changes restored
 
 - `git commit` is blocked (pre-commit hook will error)
 - `git-shadow diff` and `git-shadow rebase` are blocked
+- `git-shadow export` is blocked (resume first, so the archive captures your shadow content)
 - `git-shadow status` shows "SUSPENDED" state
 - `git-shadow doctor` reports suspended state as a warning
+
+## Migrating to a New Machine
+
+Shadow state lives under `.git/shadow/` and in `.git/info/exclude`, so it is **not** carried by `git clone`. To move your local-only setup to a freshly cloned repository on another machine, use `export` / `import`.
+
+> If you migrate your whole disk (or copy the entire `.git` directory), shadow state comes along automatically and no export/import is needed. `export` / `import` are for the common case of a fresh clone.
+
+### Export
+
+```bash
+# Bundle all managed state into a portable archive
+git-shadow export
+
+# → exported 2 managed file(s) to `/path/to/git-shadow-export.tar.gz`
+
+# Or choose the output path explicitly
+git-shadow export ~/backups/shadow.tar.gz
+
+# Overwrite an existing archive
+git-shadow export --force ~/backups/shadow.tar.gz
+```
+
+The archive is a gzipped tar (`.tar.gz`) with a `manifest.json` (`format_version`, tool version) plus one content member per managed entry. It includes:
+
+- **overlay** — the current working-tree (shadow) content **and** the stored baseline **and** the baseline commit, so `import` can 3-way merge if the target repository has moved on.
+- **phantom file** — the file's content.
+- **phantom directory** — every file under it, recursively.
+
+Binary content is stored as raw bytes and round-trips byte-for-byte. Export refuses to run when nothing is managed, while shadow is suspended (run `git-shadow resume` first), or while a commit cycle is mid-flight (stash remnant / live lock). The default output file is `git-shadow-export.tar.gz` in the current directory; existing files are not overwritten without `--force`.
+
+### Import
+
+On the new machine, clone the repository, run `git-shadow install`, then import:
+
+```bash
+git clone <repo-url> myrepo
+cd myrepo
+git-shadow install
+git-shadow import /path/to/git-shadow-export.tar.gz
+
+# → config.txt: imported overlay
+#   notes.md: imported phantom
+#   import finished: 2 imported, 0 skipped
+```
+
+Import is **safe by default** and continues past problems, reporting a summary at the end:
+
+- **phantom file / directory** — written and registered if the path is absent, or if it already exists with identical content (idempotent). If it exists with **different** content, the file is skipped with a per-file message and the command exits non-zero. `--force` overwrites instead.
+- **overlay** — the target must be tracked in HEAD (otherwise it is skipped: the repository does not match the export). The baseline is regenerated from the current HEAD. If HEAD matches the archived baseline, the shadow content is written directly; otherwise a 3-way merge (archived baseline / archived shadow / current HEAD) re-applies your shadow changes on top of upstream. A clean merge is written; a **conflict** is skipped (no conflict markers are written) and the command exits non-zero. `--force` keeps the shadow version, discarding the conflicting upstream hunk.
+- **already-managed entries** — an identical re-import is a no-op; an entry managed under a different type is skipped unless `--force` replaces it.
+
+Because import continues past conflicts, **re-running it after resolving** (removing the conflicting local edit, or passing `--force`) completes the remaining entries. Import requires `git-shadow install` first and refuses to run while suspended or mid-commit; it also validates the manifest's `format_version` and errors clearly on an unknown version.
 
 ## Recovery
 

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -15,6 +15,7 @@ Root source directory. Modules are split by responsibility into focused, small f
 | `exclude.rs` | `.git/info/exclude` section management | `ExcludeManager` |
 | `diff_util.rs` | Unified diff formatting with colors | `unified_diff()`, `print_colored_diff()` |
 | `merge.rs` | 3-way merge via `git merge-file -p --diff3` | `three_way_merge()`, `MergeResult` |
+| `archive.rs` | Portable export/import archive format (tar.gz + manifest.json) | `Manifest`, `ManifestEntry`, `write_archive()`, `read_archive()` |
 | `ui.rs` | Locale (ja/en) detection + user-facing message/error formatting | `UiLocale`, `detect_locale()`, `format_error()` |
 | `cli.rs` | clap derive definitions | `Cli`, `Commands` enum |
 | `main.rs` | Entry point, dispatches to commands | - |

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -1,0 +1,266 @@
+//! Portable archive format for `git-shadow export` / `import`.
+//!
+//! The archive is a gzipped tar (`.tar.gz`) containing a `manifest.json` plus
+//! one content file per managed entry. Tar member names are flat (path
+//! separators are URL-encoded via [`crate::path::encode_path`]) so nested repo
+//! paths never create nested tar directories:
+//!
+//! - `overlay/<encoded-path>`   -- overlay shadow (working-tree) content
+//! - `baseline/<encoded-path>`  -- overlay pristine baseline content
+//! - `phantom/<encoded-path>`   -- phantom file content
+//! - `phantomdir/<encoded-member-path>` -- one entry per file under a phantom dir
+//!
+//! Contents are stored as raw bytes (`Vec<u8>`), so binary phantom/overlay
+//! files round-trip byte-for-byte with no UTF-8 assumption.
+
+use std::collections::BTreeMap;
+use std::io::{Read, Write};
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+use crate::config::ExcludeMode;
+use crate::path;
+
+/// Current archive format version. Bumped on incompatible changes.
+pub const FORMAT_VERSION: u32 = 1;
+
+/// Name of the manifest member inside the archive.
+pub const MANIFEST_NAME: &str = "manifest.json";
+
+/// Type of a managed entry as recorded in the manifest.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ManifestType {
+    Overlay,
+    Phantom,
+    PhantomDir,
+}
+
+/// One managed entry described in the manifest.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ManifestEntry {
+    /// Repository-relative path of the entry.
+    pub path: String,
+    #[serde(rename = "type")]
+    pub entry_type: ManifestType,
+    pub exclude_mode: ExcludeMode,
+    /// Overlay only: the commit the archived baseline was captured from.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub baseline_commit: Option<String>,
+    /// Phantom dir only: repo-relative paths of every member file.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dir_members: Option<Vec<String>>,
+}
+
+/// Top-level archive manifest.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Manifest {
+    pub format_version: u32,
+    pub tool_version: String,
+    pub entries: Vec<ManifestEntry>,
+}
+
+/// Tar member name for an overlay's shadow (working-tree) content.
+pub fn overlay_shadow_key(path: &str) -> String {
+    format!("overlay/{}", path::encode_path(path))
+}
+
+/// Tar member name for an overlay's pristine baseline content.
+pub fn overlay_baseline_key(path: &str) -> String {
+    format!("baseline/{}", path::encode_path(path))
+}
+
+/// Tar member name for a phantom file's content.
+pub fn phantom_key(path: &str) -> String {
+    format!("phantom/{}", path::encode_path(path))
+}
+
+/// Tar member name for a single file under a phantom directory.
+pub fn phantom_dir_member_key(member_path: &str) -> String {
+    format!("phantomdir/{}", path::encode_path(member_path))
+}
+
+/// Write a gzipped tar archive containing the manifest and content files.
+///
+/// The write is atomic: the archive is built in a temporary file in the target's
+/// parent directory and renamed into place, so a crash mid-write cannot leave a
+/// truncated archive at `output`.
+pub fn write_archive(
+    output: &Path,
+    manifest: &Manifest,
+    contents: &BTreeMap<String, Vec<u8>>,
+) -> Result<()> {
+    let parent = output
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|| std::path::PathBuf::from("."));
+
+    let tmp = tempfile::Builder::new()
+        .prefix(".git-shadow-export-")
+        .suffix(".tmp")
+        .tempfile_in(&parent)
+        .context("failed to create temporary archive file")?;
+
+    {
+        let encoder = flate2::write::GzEncoder::new(
+            std::io::BufWriter::new(tmp.as_file()),
+            flate2::Compression::default(),
+        );
+        let mut builder = tar::Builder::new(encoder);
+
+        let manifest_json =
+            serde_json::to_vec_pretty(manifest).context("failed to serialize manifest")?;
+        append_bytes(&mut builder, MANIFEST_NAME, &manifest_json)?;
+
+        for (name, data) in contents {
+            append_bytes(&mut builder, name, data)?;
+        }
+
+        let encoder = builder.into_inner().context("failed to finalize tar")?;
+        let writer = encoder.finish().context("failed to finish gzip stream")?;
+        writer
+            .into_inner()
+            .map_err(|e| anyhow::anyhow!("failed to flush archive: {}", e.into_error()))?;
+    }
+
+    tmp.persist(output)
+        .map_err(|e| anyhow::anyhow!("failed to write archive to {}: {}", output.display(), e))?;
+    Ok(())
+}
+
+fn append_bytes<W: Write>(builder: &mut tar::Builder<W>, name: &str, data: &[u8]) -> Result<()> {
+    let mut header = tar::Header::new_gnu();
+    header.set_size(data.len() as u64);
+    header.set_mode(0o644);
+    header.set_cksum();
+    builder
+        .append_data(&mut header, name, data)
+        .with_context(|| format!("failed to append {} to archive", name))?;
+    Ok(())
+}
+
+/// Read a gzipped tar archive, returning its manifest and all content members.
+pub fn read_archive(input: &Path) -> Result<(Manifest, BTreeMap<String, Vec<u8>>)> {
+    let file = std::fs::File::open(input)
+        .with_context(|| format!("failed to open archive {}", input.display()))?;
+    let decoder = flate2::read::GzDecoder::new(std::io::BufReader::new(file));
+    let mut archive = tar::Archive::new(decoder);
+
+    let mut contents: BTreeMap<String, Vec<u8>> = BTreeMap::new();
+    let mut manifest: Option<Manifest> = None;
+
+    for entry in archive
+        .entries()
+        .context("failed to read archive entries")?
+    {
+        let mut entry = entry.context("failed to read archive entry")?;
+        let name = entry
+            .path()
+            .context("archive entry has an invalid path")?
+            .to_string_lossy()
+            .to_string();
+
+        let mut buf = Vec::new();
+        entry
+            .read_to_end(&mut buf)
+            .with_context(|| format!("failed to read archive member {}", name))?;
+
+        if name == MANIFEST_NAME {
+            manifest = Some(serde_json::from_slice(&buf).context("failed to parse manifest.json")?);
+        } else {
+            contents.insert(name, buf);
+        }
+    }
+
+    let manifest = manifest.context("archive is missing manifest.json")?;
+    Ok((manifest, contents))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_manifest() -> Manifest {
+        Manifest {
+            format_version: FORMAT_VERSION,
+            tool_version: "0.0.0-test".to_string(),
+            entries: vec![
+                ManifestEntry {
+                    path: "CLAUDE.md".to_string(),
+                    entry_type: ManifestType::Overlay,
+                    exclude_mode: ExcludeMode::None,
+                    baseline_commit: Some("abc1234".to_string()),
+                    dir_members: None,
+                },
+                ManifestEntry {
+                    path: ".claude".to_string(),
+                    entry_type: ManifestType::PhantomDir,
+                    exclude_mode: ExcludeMode::GitInfoExclude,
+                    baseline_commit: None,
+                    dir_members: Some(vec![".claude/settings.json".to_string()]),
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn test_key_encoding_is_flat() {
+        assert_eq!(overlay_shadow_key("a/b.md"), "overlay/a%2Fb.md");
+        assert_eq!(overlay_baseline_key("a/b.md"), "baseline/a%2Fb.md");
+        assert_eq!(phantom_key("dir/x"), "phantom/dir%2Fx");
+        assert_eq!(
+            phantom_dir_member_key(".claude/s.json"),
+            "phantomdir/.claude%2Fs.json"
+        );
+    }
+
+    #[test]
+    fn test_write_and_read_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let output = dir.path().join("export.tar.gz");
+
+        let mut contents = BTreeMap::new();
+        contents.insert(overlay_shadow_key("CLAUDE.md"), b"# shadow\n".to_vec());
+        contents.insert(overlay_baseline_key("CLAUDE.md"), b"# base\n".to_vec());
+        // Binary content with a null byte must survive intact.
+        contents.insert(
+            phantom_dir_member_key(".claude/settings.json"),
+            vec![0x00, 0x01, 0xff, b'x'],
+        );
+
+        write_archive(&output, &sample_manifest(), &contents).unwrap();
+        assert!(output.exists());
+
+        let (manifest, read) = read_archive(&output).unwrap();
+        assert_eq!(manifest.format_version, FORMAT_VERSION);
+        assert_eq!(manifest.entries.len(), 2);
+        assert_eq!(
+            read.get(&overlay_shadow_key("CLAUDE.md")).unwrap(),
+            b"# shadow\n"
+        );
+        assert_eq!(
+            read.get(&phantom_dir_member_key(".claude/settings.json"))
+                .unwrap(),
+            &vec![0x00, 0x01, 0xff, b'x']
+        );
+    }
+
+    #[test]
+    fn test_read_missing_manifest_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        let output = dir.path().join("bad.tar.gz");
+
+        // Build an archive with no manifest.
+        let file = std::fs::File::create(&output).unwrap();
+        let encoder = flate2::write::GzEncoder::new(file, flate2::Compression::default());
+        let mut builder = tar::Builder::new(encoder);
+        append_bytes(&mut builder, "phantom/x", b"data").unwrap();
+        builder.into_inner().unwrap().finish().unwrap();
+
+        let err = read_archive(&output).unwrap_err();
+        assert!(err.to_string().contains("manifest"));
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -80,6 +80,24 @@ pub enum Commands {
         file: Option<String>,
     },
 
+    /// Export git-shadow state to a portable archive
+    Export {
+        /// Output archive path (default: git-shadow-export.tar.gz)
+        output: Option<String>,
+        /// Overwrite the output file if it already exists
+        #[arg(long)]
+        force: bool,
+    },
+
+    /// Import git-shadow state from a portable archive
+    Import {
+        /// Path to the archive to import
+        archive: String,
+        /// Overwrite conflicting files and replace differing entries
+        #[arg(long)]
+        force: bool,
+    },
+
     /// Suspend shadow changes for branch switching
     Suspend,
 
@@ -249,6 +267,42 @@ fn localize_subcommands(command: clap::Command, locale: UiLocale) -> clap::Comma
             arg.help(match locale {
                 UiLocale::Ja => "対象ファイルのパス (省略時は全件)",
                 UiLocale::En => "Target file path (omit for all files)",
+            })
+        })
+    });
+    let command = command.mut_subcommand("export", |sub| {
+        sub.about(match locale {
+            UiLocale::Ja => "git-shadow の state をポータブルな archive に export する",
+            UiLocale::En => "Export git-shadow state to a portable archive",
+        })
+        .mut_arg("output", |arg| {
+            arg.help(match locale {
+                UiLocale::Ja => "出力先の archive パス (既定: git-shadow-export.tar.gz)",
+                UiLocale::En => "Output archive path (default: git-shadow-export.tar.gz)",
+            })
+        })
+        .mut_arg("force", |arg| {
+            arg.help(match locale {
+                UiLocale::Ja => "出力先が既に存在しても上書きする",
+                UiLocale::En => "Overwrite the output file if it already exists",
+            })
+        })
+    });
+    let command = command.mut_subcommand("import", |sub| {
+        sub.about(match locale {
+            UiLocale::Ja => "ポータブルな archive から git-shadow の state を import する",
+            UiLocale::En => "Import git-shadow state from a portable archive",
+        })
+        .mut_arg("archive", |arg| {
+            arg.help(match locale {
+                UiLocale::Ja => "import する archive のパス",
+                UiLocale::En => "Path to the archive to import",
+            })
+        })
+        .mut_arg("force", |arg| {
+            arg.help(match locale {
+                UiLocale::Ja => "衝突するファイルを上書きし、異なる登録を置き換える",
+                UiLocale::En => "Overwrite conflicting files and replace differing entries",
             })
         })
     });

--- a/src/commands/CLAUDE.md
+++ b/src/commands/CLAUDE.md
@@ -16,6 +16,8 @@ User-facing CLI commands. Each file corresponds to one subcommand and exposes a 
 | `git-shadow restore [file]` | `restore.rs` | Recovers from interrupted commits |
 | `git-shadow suspend` | `suspend.rs` | Suspends shadow changes for branch switching |
 | `git-shadow resume` | `resume.rs` | Resumes suspended shadow changes (with 3-way merge) |
+| `git-shadow export [path]` | `export.rs` | Bundles managed state into a portable archive |
+| `git-shadow import <archive>` | `import.rs` | Restores managed state from an archive (3-way merge, safe-by-default) |
 | `git-shadow doctor` | `doctor.rs` | Diagnoses hooks, config, stale state (`--json`, non-zero exit on issues) |
 | `git-shadow hook <name>` | `hook.rs` | Internal dispatcher called from hook scripts |
 
@@ -62,6 +64,12 @@ Saves shadow changes to `.git/shadow/suspended/` (separate from `stash/` which i
 ### resume.rs: Restore Suspended Changes
 
 Restores suspended shadow changes. If baseline is unchanged, restores directly. If baseline changed (different branch), performs 3-way merge via `merge::three_way_merge()`. Creates parent directories before writing (may be missing after branch switch). Cleans up `suspended/` directory and sets `config.suspended = false`.
+
+### export.rs / import.rs: Machine Migration
+
+`export` bundles per-worktree shadow state into a portable `.tar.gz` (see `src/archive.rs`): a `manifest.json` (`format_version`, tool version, per-entry metadata) plus content members named flatly via `path::encode_path` (`overlay/`, `baseline/`, `phantom/`, `phantomdir/`). For overlays it stores both the working-tree (shadow) content and the stored baseline (+ baseline_commit) so import can 3-way merge. Contents are `Vec<u8>` (binary-safe). Guards mirror uninstall/suspend: refuses when nothing is managed (`NothingToExport`), while suspended (`Suspended`), or mid-commit (`StashRemaining` / live `LockHeld`); refuses to overwrite the output unless `--force` (default `git-shadow-export.tar.gz`).
+
+`import` is safe-by-default and continues past problems, printing a `imported N, skipped M` summary and exiting non-zero if anything was skipped (`ImportSomeSkipped`). It requires `install` (`NotInitialized`), refuses while suspended/mid-commit, and validates `format_version` (`UnsupportedExportVersion`). Per entry: phantoms are written if absent or byte-identical (idempotent), skipped on differing content unless `--force`. Overlays must be tracked in HEAD (else skip); the baseline is regenerated from current HEAD, and the working tree gets the archived shadow (HEAD == archived baseline) or a 3-way merge (`merge::three_way_merge`) of archived-baseline / archived-shadow / current-HEAD — clean merges are written, conflicts are skipped without writing markers unless `--force` (shadow wins). Phantom registration + `.git/info/exclude` reuse `add`'s machinery (`exclude::union_patterns` + `ExcludeManager::set_entries`).
 
 ### hook.rs: Hidden Command
 

--- a/src/commands/export.rs
+++ b/src/commands/export.rs
@@ -1,0 +1,361 @@
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use colored::Colorize;
+
+use crate::archive::{self, Manifest, ManifestEntry, ManifestType};
+use crate::config::{FileType, ShadowConfig};
+use crate::error::ShadowError;
+use crate::git::GitRepo;
+use crate::lock::{self, LockStatus};
+use crate::path;
+use crate::ui;
+
+const DEFAULT_OUTPUT: &str = "git-shadow-export.tar.gz";
+
+pub fn run(output: Option<String>, force: bool) -> Result<()> {
+    let locale = ui::detect_locale();
+    let cwd = std::env::current_dir()?;
+    let git = GitRepo::discover(&cwd)?;
+    git.ensure_initialized()?;
+    let config = ShadowConfig::load(&git.shadow_dir)?;
+
+    guard_exportable(&git, &config)?;
+
+    let output_path = resolve_output(output, &cwd);
+    if output_path.exists() && !force {
+        return Err(ShadowError::ExportFileExists(output_path.display().to_string()).into());
+    }
+
+    let (manifest, contents) = collect_export(&git, &config)?;
+    archive::write_archive(&output_path, &manifest, &contents)?;
+
+    println!(
+        "{}",
+        ui::export_success(
+            locale,
+            manifest.entries.len(),
+            &output_path.display().to_string()
+        )
+        .green()
+    );
+    Ok(())
+}
+
+fn resolve_output(output: Option<String>, cwd: &Path) -> PathBuf {
+    match output {
+        Some(o) => {
+            let p = PathBuf::from(&o);
+            if p.is_absolute() {
+                p
+            } else {
+                cwd.join(p)
+            }
+        }
+        None => cwd.join(DEFAULT_OUTPUT),
+    }
+}
+
+/// Refuse to export in states where the exported content would be wrong or where a
+/// commit cycle is mid-flight. Mirrors the guard patterns used by uninstall/suspend.
+fn guard_exportable(git: &GitRepo, config: &ShadowConfig) -> Result<()> {
+    if config.files.is_empty() {
+        return Err(ShadowError::NothingToExport.into());
+    }
+
+    // Suspended: worktree files hold baseline content, so "shadow content" would be
+    // empty/wrong. Tell the user to resume first.
+    if config.suspended {
+        return Err(ShadowError::Suspended.into());
+    }
+
+    // Leftover stash means a commit cycle was interrupted.
+    let stash_dir = git.shadow_dir.join("stash");
+    if stash_dir.exists() {
+        let has_files = std::fs::read_dir(&stash_dir)
+            .ok()
+            .map(|entries| {
+                entries
+                    .filter_map(|e| e.ok())
+                    .any(|e| e.file_type().map(|t| t.is_file()).unwrap_or(false))
+            })
+            .unwrap_or(false);
+        if has_files {
+            return Err(ShadowError::StashRemaining.into());
+        }
+    }
+
+    // A live lock means another git-shadow process is committing right now.
+    if let Ok(LockStatus::HeldByOther(info)) = lock::check_lock(&git.shadow_dir) {
+        return Err(ShadowError::LockHeld {
+            pid: info.pid,
+            timestamp: info.timestamp.to_rfc3339(),
+        }
+        .into());
+    }
+
+    Ok(())
+}
+
+/// Gather the manifest and content files for every managed entry.
+fn collect_export(
+    git: &GitRepo,
+    config: &ShadowConfig,
+) -> Result<(Manifest, BTreeMap<String, Vec<u8>>)> {
+    let mut entries = Vec::new();
+    let mut contents: BTreeMap<String, Vec<u8>> = BTreeMap::new();
+
+    for (file_path, entry) in &config.files {
+        match entry.file_type {
+            FileType::Overlay => {
+                let worktree_path = git.root.join(file_path);
+                let shadow = std::fs::read(&worktree_path).with_context(|| {
+                    format!(
+                        "failed to read working-tree content for overlay {}",
+                        file_path
+                    )
+                })?;
+
+                let encoded = path::encode_path(file_path);
+                let baseline_path = git.shadow_dir.join("baselines").join(&encoded);
+                if !baseline_path.exists() {
+                    return Err(ShadowError::BaselineMissing(file_path.clone()).into());
+                }
+                let baseline = std::fs::read(&baseline_path)
+                    .with_context(|| format!("failed to read baseline for {}", file_path))?;
+
+                contents.insert(archive::overlay_shadow_key(file_path), shadow);
+                contents.insert(archive::overlay_baseline_key(file_path), baseline);
+
+                entries.push(ManifestEntry {
+                    path: file_path.clone(),
+                    entry_type: ManifestType::Overlay,
+                    exclude_mode: entry.exclude_mode.clone(),
+                    baseline_commit: entry.baseline_commit.clone(),
+                    dir_members: None,
+                });
+            }
+            FileType::Phantom if !entry.is_directory => {
+                let worktree_path = git.root.join(file_path);
+                let content = std::fs::read(&worktree_path).with_context(|| {
+                    format!("failed to read phantom file {} for export", file_path)
+                })?;
+                contents.insert(archive::phantom_key(file_path), content);
+
+                entries.push(ManifestEntry {
+                    path: file_path.clone(),
+                    entry_type: ManifestType::Phantom,
+                    exclude_mode: entry.exclude_mode.clone(),
+                    baseline_commit: None,
+                    dir_members: None,
+                });
+            }
+            FileType::Phantom => {
+                // Phantom directory: archive every file under it recursively.
+                let dir_path = git.root.join(file_path);
+                if !dir_path.is_dir() {
+                    anyhow::bail!(
+                        "phantom directory {} does not exist in the working tree",
+                        file_path
+                    );
+                }
+                let mut members = Vec::new();
+                collect_dir_files(&git.root, &dir_path, &mut members)?;
+                members.sort();
+
+                for member in &members {
+                    let data = std::fs::read(git.root.join(member))
+                        .with_context(|| format!("failed to read phantom dir member {}", member))?;
+                    contents.insert(archive::phantom_dir_member_key(member), data);
+                }
+
+                entries.push(ManifestEntry {
+                    path: file_path.clone(),
+                    entry_type: ManifestType::PhantomDir,
+                    exclude_mode: entry.exclude_mode.clone(),
+                    baseline_commit: None,
+                    dir_members: Some(members),
+                });
+            }
+        }
+    }
+
+    let manifest = Manifest {
+        format_version: archive::FORMAT_VERSION,
+        tool_version: env!("CARGO_PKG_VERSION").to_string(),
+        entries,
+    };
+
+    Ok((manifest, contents))
+}
+
+/// Recursively collect repo-relative paths of every regular file under `dir`.
+fn collect_dir_files(root: &Path, dir: &Path, out: &mut Vec<String>) -> Result<()> {
+    for entry in std::fs::read_dir(dir)
+        .with_context(|| format!("failed to read directory {}", dir.display()))?
+    {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        let path = entry.path();
+        if file_type.is_dir() {
+            collect_dir_files(root, &path, out)?;
+        } else if file_type.is_file() {
+            let rel = path
+                .strip_prefix(root)
+                .with_context(|| format!("path {} is outside repo root", path.display()))?;
+            out.push(rel.to_string_lossy().replace('\\', "/"));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::ExcludeMode;
+
+    fn make_test_repo() -> (tempfile::TempDir, GitRepo) {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().to_path_buf();
+        for args in [
+            vec!["init"],
+            vec!["config", "user.name", "Test"],
+            vec!["config", "user.email", "t@t.com"],
+        ] {
+            std::process::Command::new("git")
+                .args(&args)
+                .current_dir(&root)
+                .output()
+                .unwrap();
+        }
+        std::fs::write(root.join("CLAUDE.md"), "# Team\n").unwrap();
+        std::process::Command::new("git")
+            .args(["add", "CLAUDE.md"])
+            .current_dir(&root)
+            .output()
+            .unwrap();
+        std::process::Command::new("git")
+            .args(["commit", "-m", "init"])
+            .current_dir(&root)
+            .output()
+            .unwrap();
+
+        let repo = GitRepo::discover(&root).unwrap();
+        std::fs::create_dir_all(repo.shadow_dir.join("baselines")).unwrap();
+        std::fs::create_dir_all(repo.shadow_dir.join("stash")).unwrap();
+        (dir, repo)
+    }
+
+    fn overlay_config(git: &GitRepo) -> ShadowConfig {
+        let mut config = ShadowConfig::new();
+        let commit = git.head_commit().unwrap();
+        let baseline = git.show_file("HEAD", "CLAUDE.md").unwrap();
+        let encoded = path::encode_path("CLAUDE.md");
+        crate::fs_util::atomic_write(&git.shadow_dir.join("baselines").join(&encoded), &baseline)
+            .unwrap();
+        config.add_overlay("CLAUDE.md".to_string(), commit).unwrap();
+        // Local shadow edit.
+        std::fs::write(git.root.join("CLAUDE.md"), "# Team\n# shadow\n").unwrap();
+        config
+    }
+
+    #[test]
+    fn test_guard_rejects_empty_config() {
+        let (_dir, git) = make_test_repo();
+        let config = ShadowConfig::new();
+        let err = guard_exportable(&git, &config).unwrap_err();
+        assert!(matches!(
+            err.downcast_ref::<ShadowError>(),
+            Some(ShadowError::NothingToExport)
+        ));
+    }
+
+    #[test]
+    fn test_guard_rejects_when_suspended() {
+        let (_dir, git) = make_test_repo();
+        let mut config = overlay_config(&git);
+        config.suspended = true;
+        let err = guard_exportable(&git, &config).unwrap_err();
+        assert!(matches!(
+            err.downcast_ref::<ShadowError>(),
+            Some(ShadowError::Suspended)
+        ));
+    }
+
+    #[test]
+    fn test_guard_rejects_on_stash_remnant() {
+        let (_dir, git) = make_test_repo();
+        let config = overlay_config(&git);
+        std::fs::write(git.shadow_dir.join("stash").join("old.md"), "x").unwrap();
+        let err = guard_exportable(&git, &config).unwrap_err();
+        assert!(matches!(
+            err.downcast_ref::<ShadowError>(),
+            Some(ShadowError::StashRemaining)
+        ));
+    }
+
+    #[test]
+    fn test_collect_export_overlay_includes_shadow_and_baseline() {
+        let (_dir, git) = make_test_repo();
+        let config = overlay_config(&git);
+
+        let (manifest, contents) = collect_export(&git, &config).unwrap();
+        assert_eq!(manifest.entries.len(), 1);
+        assert_eq!(manifest.entries[0].entry_type, ManifestType::Overlay);
+        assert!(manifest.entries[0].baseline_commit.is_some());
+        assert_eq!(
+            contents
+                .get(&archive::overlay_shadow_key("CLAUDE.md"))
+                .unwrap(),
+            b"# Team\n# shadow\n"
+        );
+        assert_eq!(
+            contents
+                .get(&archive::overlay_baseline_key("CLAUDE.md"))
+                .unwrap(),
+            b"# Team\n"
+        );
+    }
+
+    #[test]
+    fn test_collect_export_phantom_dir_recurses() {
+        let (_dir, git) = make_test_repo();
+        let mut config = ShadowConfig::new();
+        std::fs::create_dir_all(git.root.join(".claude/nested")).unwrap();
+        std::fs::write(git.root.join(".claude/a.json"), "{}").unwrap();
+        std::fs::write(git.root.join(".claude/nested/b.txt"), b"\x00\x01bin").unwrap();
+        config
+            .add_phantom(".claude".to_string(), ExcludeMode::GitInfoExclude, true)
+            .unwrap();
+
+        let (manifest, contents) = collect_export(&git, &config).unwrap();
+        assert_eq!(manifest.entries[0].entry_type, ManifestType::PhantomDir);
+        let members = manifest.entries[0].dir_members.clone().unwrap();
+        assert!(members.contains(&".claude/a.json".to_string()));
+        assert!(members.contains(&".claude/nested/b.txt".to_string()));
+        assert_eq!(
+            contents
+                .get(&archive::phantom_dir_member_key(".claude/nested/b.txt"))
+                .unwrap(),
+            b"\x00\x01bin"
+        );
+    }
+
+    #[test]
+    fn test_resolve_output_defaults_to_cwd() {
+        let cwd = Path::new("/tmp/repo");
+        assert_eq!(
+            resolve_output(None, cwd),
+            cwd.join("git-shadow-export.tar.gz")
+        );
+        assert_eq!(
+            resolve_output(Some("out.tar.gz".to_string()), cwd),
+            cwd.join("out.tar.gz")
+        );
+        assert_eq!(
+            resolve_output(Some("/abs/out.tar.gz".to_string()), cwd),
+            PathBuf::from("/abs/out.tar.gz")
+        );
+    }
+}

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -1,0 +1,698 @@
+use std::collections::BTreeMap;
+
+use anyhow::{Context, Result};
+use colored::Colorize;
+
+use crate::archive::{self, Manifest, ManifestEntry, ManifestType};
+use crate::config::{ExcludeMode, FileType, ShadowConfig};
+use crate::error::ShadowError;
+use crate::exclude::{self, ExcludeManager};
+use crate::fs_util;
+use crate::git::GitRepo;
+use crate::lock::{self, LockStatus};
+use crate::merge;
+use crate::path;
+use crate::ui::{self, UiLocale};
+
+#[derive(Debug, PartialEq, Eq)]
+enum Outcome {
+    Imported,
+    Skipped,
+}
+
+pub fn run(archive_path: String, force: bool) -> Result<()> {
+    let locale = ui::detect_locale();
+    let cwd = std::env::current_dir()?;
+    let git = GitRepo::discover(&cwd)?;
+
+    // Must be installed: gives NotInitialized ("Run `git-shadow install`") otherwise.
+    git.ensure_initialized()?;
+
+    let mut config = ShadowConfig::load(&git.shadow_dir)?;
+    guard_importable(&git, &config)?;
+
+    let (manifest, contents) = archive::read_archive(std::path::Path::new(&archive_path))?;
+    if manifest.format_version != archive::FORMAT_VERSION {
+        return Err(ShadowError::UnsupportedExportVersion(manifest.format_version).into());
+    }
+
+    let (imported, skipped, touched_exclude) =
+        apply_manifest(&git, &mut config, &manifest, &contents, force, locale)?;
+
+    config.save(&git.shadow_dir)?;
+
+    // Regenerate the shared exclude section from the union of all worktrees' configs,
+    // reusing add's machinery rather than duplicating pattern logic.
+    if touched_exclude {
+        let manager = ExcludeManager::new(&git.common_dir);
+        let patterns = exclude::union_patterns(&git, &config);
+        manager
+            .set_entries(&patterns)
+            .context("failed to update .git/info/exclude")?;
+    }
+
+    println!("{}", ui::import_summary(locale, imported, skipped).green());
+
+    if skipped > 0 {
+        return Err(ShadowError::ImportSomeSkipped(skipped).into());
+    }
+    Ok(())
+}
+
+/// Refuse to import while a commit cycle is mid-flight or shadow is suspended.
+fn guard_importable(git: &GitRepo, config: &ShadowConfig) -> Result<()> {
+    if config.suspended {
+        return Err(ShadowError::Suspended.into());
+    }
+
+    let stash_dir = git.shadow_dir.join("stash");
+    if stash_dir.exists() {
+        let has_files = std::fs::read_dir(&stash_dir)
+            .ok()
+            .map(|entries| {
+                entries
+                    .filter_map(|e| e.ok())
+                    .any(|e| e.file_type().map(|t| t.is_file()).unwrap_or(false))
+            })
+            .unwrap_or(false);
+        if has_files {
+            return Err(ShadowError::StashRemaining.into());
+        }
+    }
+
+    if let Ok(LockStatus::HeldByOther(info)) = lock::check_lock(&git.shadow_dir) {
+        return Err(ShadowError::LockHeld {
+            pid: info.pid,
+            timestamp: info.timestamp.to_rfc3339(),
+        }
+        .into());
+    }
+
+    Ok(())
+}
+
+/// Apply every manifest entry. Returns (imported, skipped, whether exclude needs a rewrite).
+fn apply_manifest(
+    git: &GitRepo,
+    config: &mut ShadowConfig,
+    manifest: &Manifest,
+    contents: &BTreeMap<String, Vec<u8>>,
+    force: bool,
+    locale: UiLocale,
+) -> Result<(usize, usize, bool)> {
+    let mut imported = 0usize;
+    let mut skipped = 0usize;
+    let mut touched_exclude = false;
+
+    for entry in &manifest.entries {
+        let outcome = match entry.entry_type {
+            ManifestType::Overlay => import_overlay(git, config, entry, contents, force, locale)?,
+            ManifestType::Phantom => {
+                let outcome = import_phantom_file(git, config, entry, contents, force, locale)?;
+                if outcome == Outcome::Imported && entry.exclude_mode == ExcludeMode::GitInfoExclude
+                {
+                    touched_exclude = true;
+                }
+                outcome
+            }
+            ManifestType::PhantomDir => {
+                let outcome = import_phantom_dir(git, config, entry, contents, force, locale)?;
+                if outcome == Outcome::Imported && entry.exclude_mode == ExcludeMode::GitInfoExclude
+                {
+                    touched_exclude = true;
+                }
+                outcome
+            }
+        };
+
+        match outcome {
+            Outcome::Imported => imported += 1,
+            Outcome::Skipped => skipped += 1,
+        }
+    }
+
+    Ok((imported, skipped, touched_exclude))
+}
+
+fn import_overlay(
+    git: &GitRepo,
+    config: &mut ShadowConfig,
+    entry: &ManifestEntry,
+    contents: &BTreeMap<String, Vec<u8>>,
+    force: bool,
+    locale: UiLocale,
+) -> Result<Outcome> {
+    let path = &entry.path;
+
+    let (Some(shadow), Some(archived_baseline)) = (
+        contents.get(&archive::overlay_shadow_key(path)),
+        contents.get(&archive::overlay_baseline_key(path)),
+    ) else {
+        eprintln!("{}", ui::import_missing_content(locale, path).yellow());
+        return Ok(Outcome::Skipped);
+    };
+
+    // Already managed as something else: refuse unless forced.
+    if let Some(existing) = config.get(path) {
+        if existing.file_type != FileType::Overlay && !force {
+            eprintln!("{}", ui::import_skip_already_managed(locale, path).yellow());
+            return Ok(Outcome::Skipped);
+        }
+    }
+
+    // Overlay target must be tracked in HEAD; otherwise the repo doesn't match the export.
+    let head = match git.show_file("HEAD", path) {
+        Ok(content) => content,
+        Err(_) => {
+            eprintln!(
+                "{}",
+                ui::import_skip_overlay_untracked(locale, path).yellow()
+            );
+            return Ok(Outcome::Skipped);
+        }
+    };
+
+    // Decide the working-tree content to write.
+    let mut merged = false;
+    let target: Vec<u8> = if head == *archived_baseline {
+        shadow.clone()
+    } else {
+        let base = String::from_utf8_lossy(archived_baseline);
+        let ours = String::from_utf8_lossy(shadow);
+        let theirs = String::from_utf8_lossy(&head);
+        let result = merge::three_way_merge(&base, &ours, &theirs, &git.shadow_dir)?;
+        if result.has_conflicts {
+            if force {
+                // --force: keep the shadow version, discarding the conflicting upstream hunk.
+                shadow.clone()
+            } else {
+                eprintln!(
+                    "{}",
+                    ui::import_skip_overlay_conflict(locale, path).yellow()
+                );
+                return Ok(Outcome::Skipped);
+            }
+        } else {
+            merged = true;
+            result.content.into_bytes()
+        }
+    };
+
+    // Safety: don't clobber unrelated local modifications in the working tree.
+    let worktree_path = git.root.join(path);
+    if let Ok(current) = std::fs::read(&worktree_path) {
+        if current != head && current != target && !force {
+            eprintln!(
+                "{}",
+                ui::import_skip_overlay_worktree_modified(locale, path).yellow()
+            );
+            return Ok(Outcome::Skipped);
+        }
+    }
+
+    // Baseline must represent the CURRENT HEAD (the invariant pre-commit relies on).
+    let encoded = path::encode_path(path);
+    let baseline_path = git.shadow_dir.join("baselines").join(&encoded);
+    fs_util::atomic_write(&baseline_path, &head)
+        .with_context(|| format!("failed to write baseline for {}", path))?;
+
+    if let Some(parent) = worktree_path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create parent directory for {}", path))?;
+    }
+    std::fs::write(&worktree_path, &target).with_context(|| format!("failed to write {}", path))?;
+
+    let commit = git.head_commit()?;
+    config.files.remove(path);
+    config.add_overlay(path.clone(), commit)?;
+
+    if merged {
+        println!("{}", ui::import_merged_overlay(locale, path));
+    } else {
+        println!("{}", ui::import_imported_overlay(locale, path));
+    }
+    Ok(Outcome::Imported)
+}
+
+fn import_phantom_file(
+    git: &GitRepo,
+    config: &mut ShadowConfig,
+    entry: &ManifestEntry,
+    contents: &BTreeMap<String, Vec<u8>>,
+    force: bool,
+    locale: UiLocale,
+) -> Result<Outcome> {
+    let path = &entry.path;
+
+    let Some(content) = contents.get(&archive::phantom_key(path)) else {
+        eprintln!("{}", ui::import_missing_content(locale, path).yellow());
+        return Ok(Outcome::Skipped);
+    };
+
+    if let Some(existing) = config.get(path) {
+        let same_kind = existing.file_type == FileType::Phantom && !existing.is_directory;
+        if !same_kind && !force {
+            eprintln!("{}", ui::import_skip_already_managed(locale, path).yellow());
+            return Ok(Outcome::Skipped);
+        }
+    }
+
+    let worktree_path = git.root.join(path);
+    if let Ok(current) = std::fs::read(&worktree_path) {
+        if current != *content && !force {
+            eprintln!(
+                "{}",
+                ui::import_skip_phantom_conflict(locale, path).yellow()
+            );
+            return Ok(Outcome::Skipped);
+        }
+    }
+
+    if let Some(parent) = worktree_path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create parent directory for {}", path))?;
+    }
+    std::fs::write(&worktree_path, content).with_context(|| format!("failed to write {}", path))?;
+
+    config.files.remove(path);
+    config.add_phantom(path.clone(), entry.exclude_mode.clone(), false)?;
+
+    println!("{}", ui::import_imported_phantom(locale, path));
+    Ok(Outcome::Imported)
+}
+
+fn import_phantom_dir(
+    git: &GitRepo,
+    config: &mut ShadowConfig,
+    entry: &ManifestEntry,
+    contents: &BTreeMap<String, Vec<u8>>,
+    force: bool,
+    locale: UiLocale,
+) -> Result<Outcome> {
+    let path = &entry.path;
+    let members = entry.dir_members.clone().unwrap_or_default();
+
+    // First pass: verify content is present and detect conflicts with existing files.
+    let mut any_conflict = false;
+    for member in &members {
+        let Some(content) = contents.get(&archive::phantom_dir_member_key(member)) else {
+            eprintln!("{}", ui::import_missing_content(locale, member).yellow());
+            return Ok(Outcome::Skipped);
+        };
+        let member_path = git.root.join(member);
+        if let Ok(current) = std::fs::read(&member_path) {
+            if current != *content {
+                any_conflict = true;
+            }
+        }
+    }
+
+    if any_conflict && !force {
+        eprintln!(
+            "{}",
+            ui::import_skip_phantom_conflict(locale, path).yellow()
+        );
+        return Ok(Outcome::Skipped);
+    }
+
+    if let Some(existing) = config.get(path) {
+        let same_kind = existing.file_type == FileType::Phantom && existing.is_directory;
+        if !same_kind && !force {
+            eprintln!("{}", ui::import_skip_already_managed(locale, path).yellow());
+            return Ok(Outcome::Skipped);
+        }
+    }
+
+    // Second pass: write every member.
+    for member in &members {
+        let content = contents
+            .get(&archive::phantom_dir_member_key(member))
+            .expect("member content verified in first pass");
+        let member_path = git.root.join(member);
+        if let Some(parent) = member_path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("failed to create parent directory for {}", member))?;
+        }
+        std::fs::write(&member_path, content)
+            .with_context(|| format!("failed to write {}", member))?;
+    }
+
+    config.files.remove(path);
+    config.add_phantom(path.clone(), entry.exclude_mode.clone(), true)?;
+
+    println!(
+        "{}",
+        ui::import_imported_phantom_dir(locale, path, members.len())
+    );
+    Ok(Outcome::Imported)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_test_repo() -> (tempfile::TempDir, GitRepo) {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().to_path_buf();
+        for args in [
+            vec!["init"],
+            vec!["config", "user.name", "Test"],
+            vec!["config", "user.email", "t@t.com"],
+        ] {
+            std::process::Command::new("git")
+                .args(&args)
+                .current_dir(&root)
+                .output()
+                .unwrap();
+        }
+        std::fs::write(root.join("CLAUDE.md"), "# Team\n").unwrap();
+        std::process::Command::new("git")
+            .args(["add", "CLAUDE.md"])
+            .current_dir(&root)
+            .output()
+            .unwrap();
+        std::process::Command::new("git")
+            .args(["commit", "-m", "init"])
+            .current_dir(&root)
+            .output()
+            .unwrap();
+
+        let repo = GitRepo::discover(&root).unwrap();
+        std::fs::create_dir_all(repo.shadow_dir.join("baselines")).unwrap();
+        std::fs::create_dir_all(repo.shadow_dir.join("stash")).unwrap();
+        (dir, repo)
+    }
+
+    fn overlay_entry() -> ManifestEntry {
+        ManifestEntry {
+            path: "CLAUDE.md".to_string(),
+            entry_type: ManifestType::Overlay,
+            exclude_mode: ExcludeMode::None,
+            baseline_commit: Some("oldcommit".to_string()),
+            dir_members: None,
+        }
+    }
+
+    #[test]
+    fn test_import_overlay_fast_path_writes_shadow() {
+        let (_dir, git) = make_test_repo();
+        let mut config = ShadowConfig::new();
+        let mut contents = BTreeMap::new();
+        // HEAD content is "# Team\n"; archived baseline matches -> fast path.
+        contents.insert(
+            archive::overlay_baseline_key("CLAUDE.md"),
+            b"# Team\n".to_vec(),
+        );
+        contents.insert(
+            archive::overlay_shadow_key("CLAUDE.md"),
+            b"# Team\n# shadow\n".to_vec(),
+        );
+
+        let outcome = import_overlay(
+            &git,
+            &mut config,
+            &overlay_entry(),
+            &contents,
+            false,
+            UiLocale::En,
+        )
+        .unwrap();
+        assert_eq!(outcome, Outcome::Imported);
+
+        let wt = std::fs::read_to_string(git.root.join("CLAUDE.md")).unwrap();
+        assert_eq!(wt, "# Team\n# shadow\n");
+
+        // Baseline is regenerated from current HEAD, commit set to current HEAD.
+        let baseline = std::fs::read_to_string(
+            git.shadow_dir
+                .join("baselines")
+                .join(path::encode_path("CLAUDE.md")),
+        )
+        .unwrap();
+        assert_eq!(baseline, "# Team\n");
+        let entry = config.get("CLAUDE.md").unwrap();
+        assert_eq!(
+            entry.baseline_commit.as_deref(),
+            Some(git.head_commit().unwrap().as_str())
+        );
+    }
+
+    #[test]
+    fn test_import_overlay_merges_upstream_change() {
+        let (_dir, git) = make_test_repo();
+        // Establish a multi-line base so changes can be genuinely non-overlapping.
+        let base = "l1\nl2\nl3\nl4\nl5\n";
+        std::fs::write(git.root.join("CLAUDE.md"), base).unwrap();
+        std::process::Command::new("git")
+            .args(["commit", "-am", "base"])
+            .current_dir(&git.root)
+            .output()
+            .unwrap();
+        // Upstream changes the last line only.
+        std::fs::write(git.root.join("CLAUDE.md"), "l1\nl2\nl3\nl4\nl5 upstream\n").unwrap();
+        std::process::Command::new("git")
+            .args(["commit", "-am", "upstream"])
+            .current_dir(&git.root)
+            .output()
+            .unwrap();
+
+        let mut config = ShadowConfig::new();
+        let mut contents = BTreeMap::new();
+        contents.insert(
+            archive::overlay_baseline_key("CLAUDE.md"),
+            base.as_bytes().to_vec(),
+        );
+        // Shadow changes the first line only.
+        contents.insert(
+            archive::overlay_shadow_key("CLAUDE.md"),
+            b"l1 shadow\nl2\nl3\nl4\nl5\n".to_vec(),
+        );
+
+        let outcome = import_overlay(
+            &git,
+            &mut config,
+            &overlay_entry(),
+            &contents,
+            false,
+            UiLocale::En,
+        )
+        .unwrap();
+        assert_eq!(outcome, Outcome::Imported);
+
+        let wt = std::fs::read_to_string(git.root.join("CLAUDE.md")).unwrap();
+        assert!(
+            wt.contains("l5 upstream"),
+            "should keep upstream change: {wt}"
+        );
+        assert!(wt.contains("l1 shadow"), "should keep shadow change: {wt}");
+    }
+
+    #[test]
+    fn test_import_overlay_conflict_skips() {
+        let (_dir, git) = make_test_repo();
+        // Overlapping upstream change on the same line as the shadow edit.
+        std::fs::write(git.root.join("CLAUDE.md"), "# Team upstream\n").unwrap();
+        std::process::Command::new("git")
+            .args(["commit", "-am", "upstream"])
+            .current_dir(&git.root)
+            .output()
+            .unwrap();
+
+        let mut config = ShadowConfig::new();
+        let mut contents = BTreeMap::new();
+        contents.insert(
+            archive::overlay_baseline_key("CLAUDE.md"),
+            b"# Team\n".to_vec(),
+        );
+        contents.insert(
+            archive::overlay_shadow_key("CLAUDE.md"),
+            b"# Team shadow\n".to_vec(),
+        );
+
+        let outcome = import_overlay(
+            &git,
+            &mut config,
+            &overlay_entry(),
+            &contents,
+            false,
+            UiLocale::En,
+        )
+        .unwrap();
+        assert_eq!(outcome, Outcome::Skipped);
+        assert!(config.get("CLAUDE.md").is_none());
+        // No conflict markers written to the working tree.
+        let wt = std::fs::read_to_string(git.root.join("CLAUDE.md")).unwrap();
+        assert!(!wt.contains("<<<<<<<"));
+    }
+
+    #[test]
+    fn test_import_overlay_conflict_force_keeps_shadow() {
+        let (_dir, git) = make_test_repo();
+        std::fs::write(git.root.join("CLAUDE.md"), "# Team upstream\n").unwrap();
+        std::process::Command::new("git")
+            .args(["commit", "-am", "upstream"])
+            .current_dir(&git.root)
+            .output()
+            .unwrap();
+
+        let mut config = ShadowConfig::new();
+        let mut contents = BTreeMap::new();
+        contents.insert(
+            archive::overlay_baseline_key("CLAUDE.md"),
+            b"# Team\n".to_vec(),
+        );
+        contents.insert(
+            archive::overlay_shadow_key("CLAUDE.md"),
+            b"# Team shadow\n".to_vec(),
+        );
+
+        let outcome = import_overlay(
+            &git,
+            &mut config,
+            &overlay_entry(),
+            &contents,
+            true,
+            UiLocale::En,
+        )
+        .unwrap();
+        assert_eq!(outcome, Outcome::Imported);
+        let wt = std::fs::read_to_string(git.root.join("CLAUDE.md")).unwrap();
+        assert_eq!(wt, "# Team shadow\n");
+    }
+
+    #[test]
+    fn test_import_overlay_untracked_skips() {
+        let (_dir, git) = make_test_repo();
+        let mut config = ShadowConfig::new();
+        let mut contents = BTreeMap::new();
+        let entry = ManifestEntry {
+            path: "not-in-repo.md".to_string(),
+            entry_type: ManifestType::Overlay,
+            exclude_mode: ExcludeMode::None,
+            baseline_commit: Some("x".to_string()),
+            dir_members: None,
+        };
+        contents.insert(
+            archive::overlay_baseline_key("not-in-repo.md"),
+            b"a\n".to_vec(),
+        );
+        contents.insert(
+            archive::overlay_shadow_key("not-in-repo.md"),
+            b"b\n".to_vec(),
+        );
+
+        let outcome =
+            import_overlay(&git, &mut config, &entry, &contents, false, UiLocale::En).unwrap();
+        assert_eq!(outcome, Outcome::Skipped);
+    }
+
+    #[test]
+    fn test_import_phantom_file_new_and_idempotent() {
+        let (_dir, git) = make_test_repo();
+        let mut config = ShadowConfig::new();
+        let mut contents = BTreeMap::new();
+        contents.insert(archive::phantom_key("local.md"), b"# Local\n".to_vec());
+        let entry = ManifestEntry {
+            path: "local.md".to_string(),
+            entry_type: ManifestType::Phantom,
+            exclude_mode: ExcludeMode::GitInfoExclude,
+            baseline_commit: None,
+            dir_members: None,
+        };
+
+        let outcome =
+            import_phantom_file(&git, &mut config, &entry, &contents, false, UiLocale::En).unwrap();
+        assert_eq!(outcome, Outcome::Imported);
+        assert_eq!(
+            std::fs::read_to_string(git.root.join("local.md")).unwrap(),
+            "# Local\n"
+        );
+
+        // Second import: identical content -> idempotent, still Imported.
+        let outcome =
+            import_phantom_file(&git, &mut config, &entry, &contents, false, UiLocale::En).unwrap();
+        assert_eq!(outcome, Outcome::Imported);
+    }
+
+    #[test]
+    fn test_import_phantom_file_conflict_skips_without_force() {
+        let (_dir, git) = make_test_repo();
+        std::fs::write(git.root.join("local.md"), "# Different\n").unwrap();
+
+        let mut config = ShadowConfig::new();
+        let mut contents = BTreeMap::new();
+        contents.insert(archive::phantom_key("local.md"), b"# Local\n".to_vec());
+        let entry = ManifestEntry {
+            path: "local.md".to_string(),
+            entry_type: ManifestType::Phantom,
+            exclude_mode: ExcludeMode::GitInfoExclude,
+            baseline_commit: None,
+            dir_members: None,
+        };
+
+        let outcome =
+            import_phantom_file(&git, &mut config, &entry, &contents, false, UiLocale::En).unwrap();
+        assert_eq!(outcome, Outcome::Skipped);
+        // Existing file untouched.
+        assert_eq!(
+            std::fs::read_to_string(git.root.join("local.md")).unwrap(),
+            "# Different\n"
+        );
+
+        // With --force it overwrites.
+        let outcome =
+            import_phantom_file(&git, &mut config, &entry, &contents, true, UiLocale::En).unwrap();
+        assert_eq!(outcome, Outcome::Imported);
+        assert_eq!(
+            std::fs::read_to_string(git.root.join("local.md")).unwrap(),
+            "# Local\n"
+        );
+    }
+
+    #[test]
+    fn test_import_phantom_dir_writes_members() {
+        let (_dir, git) = make_test_repo();
+        let mut config = ShadowConfig::new();
+        let mut contents = BTreeMap::new();
+        contents.insert(
+            archive::phantom_dir_member_key(".claude/a.json"),
+            b"{}".to_vec(),
+        );
+        contents.insert(
+            archive::phantom_dir_member_key(".claude/n/b.bin"),
+            vec![0x00, 0x01],
+        );
+        let entry = ManifestEntry {
+            path: ".claude".to_string(),
+            entry_type: ManifestType::PhantomDir,
+            exclude_mode: ExcludeMode::GitInfoExclude,
+            baseline_commit: None,
+            dir_members: Some(vec![
+                ".claude/a.json".to_string(),
+                ".claude/n/b.bin".to_string(),
+            ]),
+        };
+
+        let outcome =
+            import_phantom_dir(&git, &mut config, &entry, &contents, false, UiLocale::En).unwrap();
+        assert_eq!(outcome, Outcome::Imported);
+        assert_eq!(
+            std::fs::read(git.root.join(".claude/n/b.bin")).unwrap(),
+            vec![0x00, 0x01]
+        );
+        let e = config.get(".claude").unwrap();
+        assert!(e.is_directory);
+    }
+
+    #[test]
+    fn test_guard_rejects_when_suspended() {
+        let (_dir, git) = make_test_repo();
+        let mut config = ShadowConfig::new();
+        config.suspended = true;
+        let err = guard_importable(&git, &config).unwrap_err();
+        assert!(matches!(
+            err.downcast_ref::<ShadowError>(),
+            Some(ShadowError::Suspended)
+        ));
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,7 +1,9 @@
 pub mod add;
 pub mod diff;
 pub mod doctor;
+pub mod export;
 pub mod hook;
+pub mod import;
 pub mod install;
 pub mod rebase;
 pub mod remove;

--- a/src/error.rs
+++ b/src/error.rs
@@ -88,6 +88,18 @@ pub enum ShadowError {
     #[error("doctor found {0} issue(s)")]
     DoctorFoundIssues(usize),
 
+    #[error("nothing to export; no files are managed by git-shadow")]
+    NothingToExport,
+
+    #[error("output file '{0}' already exists. Use --force to overwrite")]
+    ExportFileExists(String),
+
+    #[error("unsupported export format version {0}; upgrade git-shadow")]
+    UnsupportedExportVersion(u32),
+
+    #[error("{0} file(s) could not be imported; see the messages above")]
+    ImportSomeSkipped(usize),
+
     #[error("cannot run in non-interactive mode without --force")]
     NonInteractiveWithoutForce,
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod archive;
 pub mod cli;
 pub mod commands;
 pub mod config;

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,8 @@ fn run() -> anyhow::Result<()> {
         Commands::Diff { file } => commands::diff::run(file.as_deref())?,
         Commands::Rebase { file } => commands::rebase::run(file.as_deref())?,
         Commands::Restore { file } => commands::restore::run(file.as_deref())?,
+        Commands::Export { output, force } => commands::export::run(output, force)?,
+        Commands::Import { archive, force } => commands::import::run(archive, force)?,
         Commands::Suspend => commands::suspend::run()?,
         Commands::Resume => commands::resume::run()?,
         Commands::Doctor { json } => commands::doctor::run(json)?,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -763,6 +763,115 @@ pub fn status_git_wrapper_hint(locale: UiLocale) -> &'static str {
     )
 }
 
+pub fn export_success(locale: UiLocale, count: usize, output: &str) -> String {
+    match locale {
+        UiLocale::Ja => format!("{count} 件の管理対象を `{output}` に export しました"),
+        UiLocale::En => format!("exported {count} managed file(s) to `{output}`"),
+    }
+}
+
+pub fn import_success(locale: UiLocale, count: usize) -> String {
+    match locale {
+        UiLocale::Ja => format!("{count} 件のファイルを import しました"),
+        UiLocale::En => format!("imported {count} file(s)"),
+    }
+}
+
+pub fn import_summary(locale: UiLocale, imported: usize, skipped: usize) -> String {
+    match locale {
+        UiLocale::Ja => format!("import 完了: {imported} 件成功 / {skipped} 件スキップ"),
+        UiLocale::En => format!("import finished: {imported} imported, {skipped} skipped"),
+    }
+}
+
+pub fn import_imported_overlay(locale: UiLocale, path: &str) -> String {
+    match locale {
+        UiLocale::Ja => format!("{path}: overlay を import しました"),
+        UiLocale::En => format!("{path}: imported overlay"),
+    }
+}
+
+pub fn import_merged_overlay(locale: UiLocale, path: &str) -> String {
+    match locale {
+        UiLocale::Ja => format!("{path}: overlay を import し upstream の変更と merge しました"),
+        UiLocale::En => format!("{path}: imported overlay and merged with upstream changes"),
+    }
+}
+
+pub fn import_imported_phantom(locale: UiLocale, path: &str) -> String {
+    match locale {
+        UiLocale::Ja => format!("{path}: phantom を import しました"),
+        UiLocale::En => format!("{path}: imported phantom"),
+    }
+}
+
+pub fn import_imported_phantom_dir(locale: UiLocale, path: &str, count: usize) -> String {
+    match locale {
+        UiLocale::Ja => format!("{path}: phantom directory を import しました ({count} entries)"),
+        UiLocale::En => format!("{path}: imported phantom directory ({count} entries)"),
+    }
+}
+
+pub fn import_skip_overlay_untracked(locale: UiLocale, path: &str) -> String {
+    match locale {
+        UiLocale::Ja => format!(
+            "skip {path}: HEAD に追跡されていません (このリポジトリは export 元と一致しません)"
+        ),
+        UiLocale::En => {
+            format!("skip {path}: not tracked in HEAD (this repository does not match the export)")
+        }
+    }
+}
+
+pub fn import_skip_overlay_conflict(locale: UiLocale, path: &str) -> String {
+    match locale {
+        UiLocale::Ja => format!(
+            "skip {path}: upstream の変更と衝突しました。手動で解消してから再度 import してください (`--force` で shadow を優先)"
+        ),
+        UiLocale::En => format!(
+            "skip {path}: conflicts with upstream changes. Resolve manually and re-import (use `--force` to keep the shadow version)"
+        ),
+    }
+}
+
+pub fn import_skip_overlay_worktree_modified(locale: UiLocale, path: &str) -> String {
+    match locale {
+        UiLocale::Ja => format!(
+            "skip {path}: working tree に import 由来でないローカル変更があります (`--force` で上書き)"
+        ),
+        UiLocale::En => format!(
+            "skip {path}: the working tree has local modifications that did not come from this import (use `--force` to overwrite)"
+        ),
+    }
+}
+
+pub fn import_skip_phantom_conflict(locale: UiLocale, path: &str) -> String {
+    match locale {
+        UiLocale::Ja => format!("skip {path}: 既に存在し内容が異なります (`--force` で上書き)"),
+        UiLocale::En => format!(
+            "skip {path}: already exists with different content (use `--force` to overwrite)"
+        ),
+    }
+}
+
+pub fn import_skip_already_managed(locale: UiLocale, path: &str) -> String {
+    match locale {
+        UiLocale::Ja => {
+            format!("skip {path}: 既に別の種類として管理されています (`--force` で置き換え)")
+        }
+        UiLocale::En => {
+            format!("skip {path}: already managed with a different type (use `--force` to replace)")
+        }
+    }
+}
+
+pub fn import_missing_content(locale: UiLocale, path: &str) -> String {
+    match locale {
+        UiLocale::Ja => format!("skip {path}: archive に内容が含まれていません"),
+        UiLocale::En => format!("skip {path}: archive is missing its content"),
+    }
+}
+
 fn choose(locale: UiLocale, ja: &'static str, en: &'static str) -> &'static str {
     match locale {
         UiLocale::Ja => ja,
@@ -914,6 +1023,19 @@ fn format_shadow_error_ja(err: &ShadowError) -> String {
         ShadowError::DoctorFoundIssues(count) => {
             format!("エラー: doctor が {count} 件の問題を検出しました")
         }
+        ShadowError::NothingToExport => {
+            "エラー: export 対象がありません。git-shadow が管理しているファイルはありません"
+                .to_string()
+        }
+        ShadowError::ExportFileExists(path) => format!(
+            "エラー: 出力先 `{path}` が既に存在します。上書きするには `--force` を使ってください"
+        ),
+        ShadowError::UnsupportedExportVersion(version) => format!(
+            "エラー: 未対応の export フォーマット version ({version}) です。git-shadow を更新してください"
+        ),
+        ShadowError::ImportSomeSkipped(count) => format!(
+            "エラー: {count} 件のファイルを import できませんでした。上のメッセージを確認してください"
+        ),
         ShadowError::NonInteractiveWithoutForce => {
             "エラー: 非対話モードでは `--force` が必要です".to_string()
         }
@@ -1052,6 +1174,18 @@ What to do:\n\
         ShadowError::DoctorFoundIssues(count) => {
             format!("Error: doctor found {count} issue(s)")
         }
+        ShadowError::NothingToExport => {
+            "Error: nothing to export; no files are managed by git-shadow".to_string()
+        }
+        ShadowError::ExportFileExists(path) => {
+            format!("Error: output file `{path}` already exists. Use `--force` to overwrite")
+        }
+        ShadowError::UnsupportedExportVersion(version) => format!(
+            "Error: unsupported export format version {version}; upgrade git-shadow"
+        ),
+        ShadowError::ImportSomeSkipped(count) => format!(
+            "Error: {count} file(s) could not be imported; see the messages above"
+        ),
         ShadowError::NonInteractiveWithoutForce => {
             "Error: `--force` is required in non-interactive mode".to_string()
         }

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -11,6 +11,7 @@ Integration and E2E tests. Unit tests live alongside their modules in `src/` via
 | `test_worktree.rs` | E2E tests for git worktree support |
 | `test_git_operations.rs` | E2E tests running real `git` commands against the installed hooks |
 | `test_localized_errors.rs` | E2E tests for locale-aware output, `--version`, `--json`, `uninstall` |
+| `test_export_import.rs` | E2E tests for `export`/`import`: clone roundtrip, upstream merge/conflict, binary, URL-encoded paths, refusals, idempotency, locale |
 
 ## TestRepo Helper
 
@@ -53,6 +54,18 @@ Six scenarios that install the real hooks and run real `git` commands (the built
 ## E2E Tests (test_localized_errors.rs)
 
 Locale-aware output and CLI-surface scenarios, including: English/Japanese error and help/status messages selected from locale env vars, `--version`, `doctor` non-zero exit on issues plus valid English `--json`, valid `status --json`, and `uninstall` removing hooks/state (and refusing with active entries).
+
+## E2E Tests (test_export_import.rs)
+
+Ten scenarios building a source repo, `export`ing, `git clone`ing to a fresh repo, and `import`ing the built binary via `PATH` (locale pinned hermetically):
+
+1. **`test_full_roundtrip_and_commit_cycle`**: overlay + phantom file + nested phantom dir → export → clone → install → import; phantom files/dir byte-identical, overlay carries shadow, then a real commit cycle leaks no shadow and restores it
+2. **`test_upstream_moved_clean_merge`**: upstream changed a non-overlapping region → import merges upstream + shadow; commit cycle stays clean
+3. **`test_upstream_moved_conflict_skips_then_force`**: overlapping change → import skips the overlay (non-zero) but imports phantoms; `--force` re-run keeps the shadow version
+4. **`test_binary_phantom_roundtrip`**: phantom with null bytes round-trips byte-identical
+5. **`test_nested_url_encoding_path_roundtrip`**: phantom dir with a space and `%` in the path round-trips
+6. **`test_import_without_install_is_rejected`**, **`test_export_nothing_managed_is_rejected_localized`** (ja + en), **`test_export_refuses_with_stash_remnant`**, **`test_import_existing_differing_phantom_conflict_and_force`**: guard/refusal coverage
+7. **`test_import_twice_is_idempotent`**: a second import exits 0 and changes nothing
 
 ## Testing Patterns
 

--- a/tests/test_export_import.rs
+++ b/tests/test_export_import.rs
@@ -1,0 +1,473 @@
+//! E2E tests for `git-shadow export` / `import`.
+//!
+//! These install the real hooks via `git-shadow install` and run the built
+//! binary from `PATH` (so committed hooks resolve it), mirroring the pattern in
+//! `test_git_operations.rs` / `test_localized_errors.rs`. Locale is pinned
+//! hermetically via `apply_locale` so assertions do not depend on the runner's
+//! ambient `LC_ALL` / `LC_MESSAGES` / `LANG`.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+fn bin_dir() -> PathBuf {
+    assert_cmd::cargo::cargo_bin!("git-shadow")
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+fn prepend_path(dir: &Path) -> String {
+    let current = std::env::var_os("PATH").unwrap_or_default();
+    let mut paths = vec![dir.to_path_buf()];
+    paths.extend(std::env::split_paths(&current));
+    std::env::join_paths(paths)
+        .unwrap()
+        .to_string_lossy()
+        .into_owned()
+}
+
+/// Pin the process locale hermetically (see `test_localized_errors.rs`).
+fn apply_locale(cmd: &mut Command, locale: &str) {
+    cmd.env("LC_ALL", locale)
+        .env("LC_MESSAGES", locale)
+        .env("LANG", locale);
+}
+
+fn git(root: &Path, args: &[&str]) -> Output {
+    let mut cmd = Command::new("git");
+    cmd.args(args)
+        .current_dir(root)
+        .env("PATH", prepend_path(&bin_dir()));
+    apply_locale(&mut cmd, "en_US.UTF-8");
+    cmd.output().unwrap()
+}
+
+fn git_ok(root: &Path, args: &[&str]) -> Output {
+    let out = git(root, args);
+    assert!(
+        out.status.success(),
+        "git {} failed:\nstdout: {}\nstderr: {}",
+        args.join(" "),
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    out
+}
+
+fn shadow(root: &Path, locale: &str, args: &[&str]) -> Output {
+    let mut cmd = Command::new("git-shadow");
+    cmd.args(args)
+        .current_dir(root)
+        .env("PATH", prepend_path(&bin_dir()));
+    apply_locale(&mut cmd, locale);
+    cmd.output().unwrap()
+}
+
+fn shadow_ok(root: &Path, args: &[&str]) -> Output {
+    let out = shadow(root, "en_US.UTF-8", args);
+    assert!(
+        out.status.success(),
+        "git-shadow {} failed:\nstdout: {}\nstderr: {}",
+        args.join(" "),
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    out
+}
+
+fn write(root: &Path, rel: &str, content: &[u8]) {
+    let p = root.join(rel);
+    if let Some(parent) = p.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    std::fs::write(p, content).unwrap();
+}
+
+fn read(root: &Path, rel: &str) -> Vec<u8> {
+    std::fs::read(root.join(rel)).unwrap()
+}
+
+fn show_head(root: &Path, rel: &str) -> Option<String> {
+    let out = git(root, &["show", &format!("HEAD:{rel}")]);
+    if out.status.success() {
+        Some(String::from_utf8_lossy(&out.stdout).to_string())
+    } else {
+        None
+    }
+}
+
+fn init_repo(root: &Path) {
+    git_ok(root, &["init"]);
+    git_ok(root, &["config", "user.name", "Test"]);
+    git_ok(root, &["config", "user.email", "test@example.com"]);
+    // Deterministic default branch name across git versions.
+    git_ok(root, &["checkout", "-B", "main"]);
+}
+
+fn clone(src: &Path, dst: &Path) {
+    let out = Command::new("git")
+        .args(["clone", src.to_str().unwrap(), dst.to_str().unwrap()])
+        .env("PATH", prepend_path(&bin_dir()))
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "git clone failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    git_ok(dst, &["config", "user.name", "Test"]);
+    git_ok(dst, &["config", "user.email", "test@example.com"]);
+}
+
+/// Build a source repo A with an overlay (with shadow changes), a phantom file,
+/// and a nested phantom directory. Returns the archive path.
+fn build_and_export(a: &Path, config_base: &str, out_dir: &Path) -> PathBuf {
+    init_repo(a);
+    write(a, "config.txt", config_base.as_bytes());
+    write(a, "README.md", b"# project\n");
+    git_ok(a, &["add", "-A"]);
+    git_ok(a, &["commit", "-m", "init"]);
+
+    shadow_ok(a, &["install"]);
+    shadow_ok(a, &["add", "config.txt"]);
+
+    // Phantom file.
+    write(a, "notes.md", b"private notes\n");
+    shadow_ok(a, &["add", "notes.md"]);
+
+    // Phantom directory with a nested file.
+    write(a, ".claude/settings.json", b"{\"key\": true}\n");
+    write(a, ".claude/nested/deep.txt", b"deep\n");
+    shadow_ok(a, &["add", ".claude"]);
+
+    let archive = out_dir.join("export.tar.gz");
+    shadow_ok(a, &["export", archive.to_str().unwrap()]);
+    assert!(archive.exists());
+    archive
+}
+
+#[test]
+fn test_full_roundtrip_and_commit_cycle() {
+    let tmp = tempfile::tempdir().unwrap();
+    let a = tmp.path().join("A");
+    let b = tmp.path().join("B");
+    std::fs::create_dir_all(&a).unwrap();
+
+    let archive = build_and_export(&a, "port=8080\n", tmp.path());
+
+    // Apply the local shadow edit to the overlay in A (after add captured baseline).
+    write(&a, "config.txt", b"port=8080\ndebug=true\n");
+    // Re-export so the archive carries the shadow content.
+    shadow_ok(&a, &["export", "--force", archive.to_str().unwrap()]);
+
+    clone(&a, &b);
+    shadow_ok(&b, &["install"]);
+
+    // Import into the fresh clone.
+    shadow_ok(&b, &["import", archive.to_str().unwrap()]);
+
+    // Phantom file and dir restored byte-identical.
+    assert_eq!(read(&b, "notes.md"), b"private notes\n");
+    assert_eq!(read(&b, ".claude/settings.json"), b"{\"key\": true}\n");
+    assert_eq!(read(&b, ".claude/nested/deep.txt"), b"deep\n");
+    // Overlay working tree carries the shadow content.
+    assert_eq!(read(&b, "config.txt"), b"port=8080\ndebug=true\n");
+
+    // git-shadow status works.
+    shadow_ok(&b, &["status"]);
+
+    // Real commit cycle: commit an unrelated real change; shadow must not leak
+    // and must be restored afterwards.
+    write(&b, "real.txt", b"real\n");
+    git_ok(&b, &["add", "real.txt"]);
+    git_ok(&b, &["commit", "-m", "add real"]);
+
+    // Overlay shadow did not leak into HEAD.
+    assert_eq!(show_head(&b, "config.txt").as_deref(), Some("port=8080\n"));
+    // Phantom files are not committed.
+    assert!(show_head(&b, "notes.md").is_none());
+    assert!(show_head(&b, ".claude/settings.json").is_none());
+    // Shadow content restored in the working tree after the commit.
+    assert_eq!(read(&b, "config.txt"), b"port=8080\ndebug=true\n");
+    assert_eq!(read(&b, "notes.md"), b"private notes\n");
+}
+
+#[test]
+fn test_upstream_moved_clean_merge() {
+    let tmp = tempfile::tempdir().unwrap();
+    let a = tmp.path().join("A");
+    let b = tmp.path().join("B");
+    std::fs::create_dir_all(&a).unwrap();
+
+    let archive = build_and_export(&a, "l1\nl2\nl3\nl4\n", tmp.path());
+    // Shadow changes the FIRST line.
+    write(&a, "config.txt", b"l1 shadow\nl2\nl3\nl4\n");
+    shadow_ok(&a, &["export", "--force", archive.to_str().unwrap()]);
+
+    clone(&a, &b);
+    shadow_ok(&b, &["install"]);
+
+    // Upstream (in B, before import) changes the LAST line — non-overlapping.
+    write(&b, "config.txt", b"l1\nl2\nl3\nl4 upstream\n");
+    git_ok(&b, &["commit", "-am", "upstream change"]);
+
+    shadow_ok(&b, &["import", archive.to_str().unwrap()]);
+
+    let merged = String::from_utf8(read(&b, "config.txt")).unwrap();
+    assert!(merged.contains("l1 shadow"), "shadow change kept: {merged}");
+    assert!(merged.contains("l4 upstream"), "upstream kept: {merged}");
+    assert!(!merged.contains("<<<<<<<"), "no conflict markers: {merged}");
+
+    // Commit cycle stays clean: HEAD keeps the upstream line, not the shadow line.
+    write(&b, "real.txt", b"x\n");
+    git_ok(&b, &["add", "real.txt"]);
+    git_ok(&b, &["commit", "-m", "real"]);
+    let head = show_head(&b, "config.txt").unwrap();
+    assert!(head.contains("l4 upstream"));
+    assert!(!head.contains("l1 shadow"), "shadow must not leak: {head}");
+}
+
+#[test]
+fn test_upstream_moved_conflict_skips_then_force() {
+    let tmp = tempfile::tempdir().unwrap();
+    let a = tmp.path().join("A");
+    let b = tmp.path().join("B");
+    std::fs::create_dir_all(&a).unwrap();
+
+    let archive = build_and_export(&a, "l1\nl2\nl3\n", tmp.path());
+    // Shadow changes line 1.
+    write(&a, "config.txt", b"l1 shadow\nl2\nl3\n");
+    shadow_ok(&a, &["export", "--force", archive.to_str().unwrap()]);
+
+    clone(&a, &b);
+    shadow_ok(&b, &["install"]);
+
+    // Upstream changes the SAME line 1 — overlapping -> conflict.
+    write(&b, "config.txt", b"l1 upstream\nl2\nl3\n");
+    git_ok(&b, &["commit", "-am", "upstream conflict"]);
+
+    // Import skips the overlay (non-zero exit) but still imports the phantoms.
+    let out = shadow(&b, "en_US.UTF-8", &["import", archive.to_str().unwrap()]);
+    assert!(!out.status.success(), "conflict import must exit non-zero");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("conflicts with upstream"),
+        "expected conflict message, got: {stderr}"
+    );
+    // Other entries imported despite the conflict.
+    assert_eq!(read(&b, "notes.md"), b"private notes\n");
+    // Overlay left untouched (no markers).
+    let wt = String::from_utf8(read(&b, "config.txt")).unwrap();
+    assert!(!wt.contains("<<<<<<<"));
+
+    // Re-run with --force: shadow wins, import succeeds.
+    let forced = shadow(
+        &b,
+        "en_US.UTF-8",
+        &["import", "--force", archive.to_str().unwrap()],
+    );
+    assert!(
+        forced.status.success(),
+        "forced import should succeed:\n{}",
+        String::from_utf8_lossy(&forced.stderr)
+    );
+    assert_eq!(read(&b, "config.txt"), b"l1 shadow\nl2\nl3\n");
+}
+
+#[test]
+fn test_binary_phantom_roundtrip() {
+    let tmp = tempfile::tempdir().unwrap();
+    let a = tmp.path().join("A");
+    let b = tmp.path().join("B");
+    std::fs::create_dir_all(&a).unwrap();
+
+    init_repo(&a);
+    write(&a, "README.md", b"# p\n");
+    git_ok(&a, &["add", "-A"]);
+    git_ok(&a, &["commit", "-m", "init"]);
+    shadow_ok(&a, &["install"]);
+
+    let binary: Vec<u8> = vec![0x00, 0x01, 0xff, 0xfe, b'x', 0x00, 0x7f];
+    write(&a, "blob.bin", &binary);
+    shadow_ok(&a, &["add", "blob.bin"]);
+
+    let archive = tmp.path().join("export.tar.gz");
+    shadow_ok(&a, &["export", archive.to_str().unwrap()]);
+
+    clone(&a, &b);
+    shadow_ok(&b, &["install"]);
+    shadow_ok(&b, &["import", archive.to_str().unwrap()]);
+
+    assert_eq!(
+        read(&b, "blob.bin"),
+        binary,
+        "binary phantom must round-trip"
+    );
+}
+
+#[test]
+fn test_nested_url_encoding_path_roundtrip() {
+    let tmp = tempfile::tempdir().unwrap();
+    let a = tmp.path().join("A");
+    let b = tmp.path().join("B");
+    std::fs::create_dir_all(&a).unwrap();
+
+    init_repo(&a);
+    write(&a, "README.md", b"# p\n");
+    git_ok(&a, &["add", "-A"]);
+    git_ok(&a, &["commit", "-m", "init"]);
+    shadow_ok(&a, &["install"]);
+
+    // Directory name with a space and a percent sign; nested file with a slash.
+    write(&a, "weird 100%dir/sub/data.txt", b"encoded path\n");
+    shadow_ok(&a, &["add", "weird 100%dir"]);
+
+    let archive = tmp.path().join("export.tar.gz");
+    shadow_ok(&a, &["export", archive.to_str().unwrap()]);
+
+    clone(&a, &b);
+    shadow_ok(&b, &["install"]);
+    shadow_ok(&b, &["import", archive.to_str().unwrap()]);
+
+    assert_eq!(
+        read(&b, "weird 100%dir/sub/data.txt"),
+        b"encoded path\n",
+        "URL-encoding-relevant nested path must round-trip"
+    );
+}
+
+#[test]
+fn test_import_without_install_is_rejected() {
+    let tmp = tempfile::tempdir().unwrap();
+    let a = tmp.path().join("A");
+    let b = tmp.path().join("B");
+    std::fs::create_dir_all(&a).unwrap();
+
+    init_repo(&a);
+    write(&a, "README.md", b"# p\n");
+    git_ok(&a, &["add", "-A"]);
+    git_ok(&a, &["commit", "-m", "init"]);
+    shadow_ok(&a, &["install"]);
+    write(&a, "notes.md", b"n\n");
+    shadow_ok(&a, &["add", "notes.md"]);
+    let archive = tmp.path().join("export.tar.gz");
+    shadow_ok(&a, &["export", archive.to_str().unwrap()]);
+
+    clone(&a, &b);
+    // No install in B.
+    let out = shadow(&b, "en_US.UTF-8", &["import", archive.to_str().unwrap()]);
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("git-shadow install"),
+        "hint install: {stderr}"
+    );
+}
+
+#[test]
+fn test_export_nothing_managed_is_rejected_localized() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    init_repo(root);
+    write(root, "README.md", b"# p\n");
+    git_ok(root, &["add", "-A"]);
+    git_ok(root, &["commit", "-m", "init"]);
+    shadow_ok(root, &["install"]);
+
+    // English message.
+    let en = shadow(root, "en_US.UTF-8", &["export"]);
+    assert!(!en.status.success());
+    assert!(String::from_utf8_lossy(&en.stderr).contains("nothing to export"));
+
+    // Japanese message (hermetic locale).
+    let ja = shadow(root, "ja_JP.UTF-8", &["export"]);
+    assert!(!ja.status.success());
+    assert!(String::from_utf8_lossy(&ja.stderr).contains("export 対象がありません"));
+}
+
+#[test]
+fn test_export_refuses_with_stash_remnant() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    init_repo(root);
+    write(root, "config.txt", b"a\n");
+    git_ok(root, &["add", "-A"]);
+    git_ok(root, &["commit", "-m", "init"]);
+    shadow_ok(root, &["install"]);
+    shadow_ok(root, &["add", "config.txt"]);
+
+    // Simulate an interrupted commit: leave a file in the stash dir.
+    let stash = root.join(".git/shadow/stash");
+    std::fs::create_dir_all(&stash).unwrap();
+    std::fs::write(stash.join("config.txt"), b"leftover").unwrap();
+
+    let archive = tmp.path().join("export.tar.gz");
+    let out = shadow(root, "en_US.UTF-8", &["export", archive.to_str().unwrap()]);
+    assert!(!out.status.success());
+    assert!(String::from_utf8_lossy(&out.stderr).contains("stash"));
+    assert!(!archive.exists());
+}
+
+#[test]
+fn test_import_existing_differing_phantom_conflict_and_force() {
+    let tmp = tempfile::tempdir().unwrap();
+    let a = tmp.path().join("A");
+    let b = tmp.path().join("B");
+    std::fs::create_dir_all(&a).unwrap();
+
+    init_repo(&a);
+    write(&a, "README.md", b"# p\n");
+    git_ok(&a, &["add", "-A"]);
+    git_ok(&a, &["commit", "-m", "init"]);
+    shadow_ok(&a, &["install"]);
+    write(&a, "notes.md", b"from A\n");
+    shadow_ok(&a, &["add", "notes.md"]);
+    let archive = tmp.path().join("export.tar.gz");
+    shadow_ok(&a, &["export", archive.to_str().unwrap()]);
+
+    clone(&a, &b);
+    shadow_ok(&b, &["install"]);
+    // Pre-existing differing file at the phantom path.
+    write(&b, "notes.md", b"already here\n");
+
+    let out = shadow(&b, "en_US.UTF-8", &["import", archive.to_str().unwrap()]);
+    assert!(!out.status.success(), "conflict must exit non-zero");
+    assert!(String::from_utf8_lossy(&out.stderr).contains("already exists"));
+    assert_eq!(read(&b, "notes.md"), b"already here\n", "left untouched");
+
+    // --force overwrites.
+    let forced = shadow(
+        &b,
+        "en_US.UTF-8",
+        &["import", "--force", archive.to_str().unwrap()],
+    );
+    assert!(forced.status.success());
+    assert_eq!(read(&b, "notes.md"), b"from A\n");
+}
+
+#[test]
+fn test_import_twice_is_idempotent() {
+    let tmp = tempfile::tempdir().unwrap();
+    let a = tmp.path().join("A");
+    let b = tmp.path().join("B");
+    std::fs::create_dir_all(&a).unwrap();
+
+    let archive = build_and_export(&a, "port=8080\n", tmp.path());
+    write(&a, "config.txt", b"port=8080\ndebug=true\n");
+    shadow_ok(&a, &["export", "--force", archive.to_str().unwrap()]);
+
+    clone(&a, &b);
+    shadow_ok(&b, &["install"]);
+
+    shadow_ok(&b, &["import", archive.to_str().unwrap()]);
+    // Second import: everything already matches -> exit 0, no changes.
+    let second = shadow(&b, "en_US.UTF-8", &["import", archive.to_str().unwrap()]);
+    assert!(
+        second.status.success(),
+        "second import should exit 0:\n{}",
+        String::from_utf8_lossy(&second.stderr)
+    );
+    assert_eq!(read(&b, "config.txt"), b"port=8080\ndebug=true\n");
+    assert_eq!(read(&b, "notes.md"), b"private notes\n");
+    assert_eq!(read(&b, ".claude/settings.json"), b"{\"key\": true}\n");
+}


### PR DESCRIPTION
Closes #21

## 概要

git-shadow が管理するローカル専用状態(overlay のローカル差分・phantom ファイル/ディレクトリ)を、新しいマシンの fresh clone に移行するための `export` / `import` コマンドを追加します。

**注**: #20(`feature/hardening-batch`)へのスタック PR です。#20 のマージ後に base が main に切り替わります。

## 設計

- **形式**: tar.gz + `manifest.json`(`format_version: 1`)。コンテンツは `path.rs` の URL エンコードを再利用したフラット配置(`overlay/` `baseline/` `phantom/` `phantomdir/`)。`Vec<u8>` 扱いでバイナリも byte-for-byte roundtrip。書き込みは temp + rename でアトミック。新規依存は `tar` + `flate2` のみ
- **export**: overlay は「shadow 内容 + baseline + baseline_commit」を保持(import 時の 3-way merge 材料)。未 install・管理対象なし・コミット進行中(stash 残留/生存 lock)・suspend 中は拒否
- **import**: baseline は移行先の現 HEAD から再生成(pre-commit の baseline == HEAD 不変条件を維持)。HEAD がアーカイブの baseline と一致すれば fast path、進んでいれば 3-way merge(base=アーカイブ baseline、ours=shadow 内容、theirs=現 HEAD)。conflict・既存ファイル衝突・型不一致は per-file でスキップ+末尾サマリ+非ゼロ exit。`--force` で上書き(overlay conflict は shadow 側を採用)。再実行は冪等
- **manifest バージョン検証**: 未知の `format_version` は明示エラー

## テスト(信頼性重視)

ユニット18件 + E2E 10件(実バイナリ+実フック+hermetic locale):

- fresh clone への full roundtrip → import 後に実 commit サイクルで shadow 漏洩なしまで確認
- upstream 移動(clean merge / conflict→skip→`--force`)
- バイナリ phantom(null バイト含む)、URL エンコード対象の特殊文字パス
- 拒否系(未 install、管理対象なし、stash 残留、既存 phantom 衝突)
- 冪等性(2回目の import が exit 0・無変更)
- ja/en 両ロケールのメッセージ検証

## ドキュメント

usage(EN/JA)に「Migrating to a new machine」セクション新設、README コマンド表、requirements.md、CLAUDE.md 群を更新。

## 検証

`cargo fmt --check` / `cargo clippy -- -D warnings` クリーン、`cargo test` 全通過(ユニット256 + E2E 35)、`LC_ALL=en_US.UTF-8` でも全通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)